### PR TITLE
docs: add manual flutter installation guide for Linux

### DIFF
--- a/SETTING_UP.md
+++ b/SETTING_UP.md
@@ -1,0 +1,26 @@
+# Setting Up MPCWallet for Development (Linux)
+
+This guide covers the setup process for Linux users, including a fix for environments where `snap` is not available.
+
+## Prerequisites
+- Git
+- Python (for script-based tasks)
+- Flutter SDK
+
+## Manual Flutter Installation (Non-Snap Method)
+If `sudo snap install flutter` fails with `snap: command not found`, follow these steps:
+
+1. **Install dependencies:**
+   `sudo apt update && sudo apt install -y curl git unzip xz-utils zip libglu1-mesa`
+2. **Clone Flutter SDK:**
+   `mkdir ~/development && cd ~/development`
+   `git clone https://github.com/flutter/flutter.git -b stable`
+3. **Add to PATH:**
+   Add `export PATH="$PATH:$HOME/development/flutter/bin"` to your `~/.bashrc` file.
+4. **Refresh Bash:**
+   `source ~/.bashrc`
+
+## Initializing the Project
+Once Flutter is installed, run:
+```bash
+flutter pub get


### PR DESCRIPTION
This PR adds a comprehensive guide to the README.md (or CONTRIBUTING.md) for manually installing the Flutter SDK on Linux systems where snap is unavailable or not preferred.

Why? During the setup process on a minimal Linux environment, I encountered a snap: command not found error. Since many developers in similar environments (or those preferring manual SDK management) might face this hurdle, adding a git-based manual installation path lowers the barrier to entry for new contributors.

How?

Added step-by-step instructions for cloning the Flutter stable branch from GitHub.

Included the necessary export PATH commands for .bashrc to ensure the SDK is recognized globally.

Verified the process on a clean Linux installation to ensure all prerequisites (curl, git, unzip, etc.) are documented.

Testing? I successfully used these manual steps to initialize the environment and run flutter pub get on this repository.