### PR TITLE
feat: Make wallet a passive DKG receiver

### DIFF
--- a/ap/lib/usb/usb_hardware_signer.dart
+++ b/ap/lib/usb/usb_hardware_signer.dart
@@ -64,18 +64,26 @@ class UsbHardwareSigner implements HardwareSignerInterface {
 
   @override
   Future<Map<Identifier, Round2Package>> dkgRound2(
-    Map<Identifier, Round1Package> othersRound1,
-  ) async {
+    Map<Identifier, Round1Package> othersRound1, {
+    List<Identifier> receiverIdentifiers = const [],
+  }) async {
     final r1Map = <String, dynamic>{};
     for (final entry in othersRound1.entries) {
       final idHex = hex.encode(entry.key.serialize());
       r1Map[idHex] = entry.value.toJson();
     }
 
-    final resp = await _transport.sendCommand({
+    final cmd = <String, dynamic>{
       'cmd': 'dkg_round2',
       'round1_packages': r1Map,
-    });
+    };
+    if (receiverIdentifiers.isNotEmpty) {
+      cmd['receiver_identifiers'] = receiverIdentifiers
+          .map((id) => hex.encode(id.serialize()))
+          .toList();
+    }
+
+    final resp = await _transport.sendCommand(cmd);
 
     final r2Map = resp['round2_packages'] as Map<String, dynamic>;
     final result = <Identifier, Round2Package>{};
@@ -97,8 +105,9 @@ class UsbHardwareSigner implements HardwareSignerInterface {
   @override
   Future<DkgFinalResult> dkgRound3(
     Map<Identifier, Round1Package> round1Pkgs,
-    Map<Identifier, Round2Package> round2Pkgs,
-  ) async {
+    Map<Identifier, Round2Package> round2Pkgs, {
+    List<Identifier> receiverIdentifiers = const [],
+  }) async {
     final r1Map = <String, dynamic>{};
     for (final entry in round1Pkgs.entries) {
       final idHex = hex.encode(entry.key.serialize());
@@ -111,11 +120,18 @@ class UsbHardwareSigner implements HardwareSignerInterface {
       r2Map[idHex] = entry.value.toJson();
     }
 
-    final resp = await _transport.sendCommand({
+    final cmd = <String, dynamic>{
       'cmd': 'dkg_round3',
       'round1_packages': r1Map,
       'round2_packages': r2Map,
-    });
+    };
+    if (receiverIdentifiers.isNotEmpty) {
+      cmd['receiver_identifiers'] = receiverIdentifiers
+          .map((id) => hex.encode(id.serialize()))
+          .toList();
+    }
+
+    final resp = await _transport.sendCommand(cmd);
 
     final idHex = resp['identifier_hex'] as String;
     final idBytes = Uint8List.fromList(hex.decode(idHex));

--- a/client/lib/client.dart
+++ b/client/lib/client.dart
@@ -194,102 +194,126 @@ class MpcClient {
 
   // --- DKG ---
 
-  /// DKG: signing identity runs locally, recovery identity
-  /// runs on the hardware signer (secret never leaves the device).
+  /// DKG: only the hardware signer and server contribute secrets (dealers).
+  /// The wallet is a passive receiver — it gets a valid signing share
+  /// without contributing key material. Group key = s_hw + s_server.
   Future<void> doDkg() async {
     await _store.init();
     final signer = _hardwareSigner;
 
-    // 1. Generate signing secret locally (participant 1 — unchanged)
-    _signingSecret = threshold.SecretKey(threshold.modNRandom());
-    final coeffs1 = threshold.generateCoefficients(_minSigners - 1);
-    final (r1Sec1, r1Pub1) =
-        threshold.dkgPart1(_maxSigners, _minSigners, _signingSecret!, coeffs1);
-
-    // 2. Hardware signer generates recovery secret (participant 2)
+    // 1. Hardware signer generates secret (dealer)
     final dkgInit = await signer.dkgInit(_maxSigners, _minSigners);
+    final hwVerifyingKey = dkgInit.verifyingKeyBytes;
+    final hwIdentifier = dkgInit.identifier;
 
-    final userId = threshold.elemSerializeCompressed(r1Pub1.verifyingKey.E);
-    final recoveryId = dkgInit.verifyingKeyBytes;
+    // 2. Derive wallet identifier deterministically from HW signer's VK
+    final walletIdInput = Uint8List.fromList(
+      [...'wallet:'.codeUnits, ...hwVerifyingKey],
+    );
+    final walletIdentifier = threshold.Identifier.derive(walletIdInput);
 
-    _userId = userId;
-    _recoveryId = recoveryId;
+    // Use HW VK as temporary session key during DKG
+    final tempUserId = Uint8List.fromList(hwVerifyingKey);
 
-    final signingIdThresholdId = threshold.Identifier.derive(userId);
-    final recoveryIdThresholdId = dkgInit.identifier;
+    // 3. Send Round1 packages to server:
+    //    - Wallet: empty round1 = passive receiver
+    //    - HW signer: actual round1 = dealer
+    final hwR1Json = jsonEncode(dkgInit.round1Package.toJson());
 
-    // 3. Send both Round1Packages to server
-    final r1Json1 = jsonEncode(r1Pub1.toJson());
-    final r1Json2 = jsonEncode(dkgInit.round1Package.toJson());
+    final reqWallet = DKGStep1Request()
+      ..userId = tempUserId
+      ..identifier = walletIdentifier.serialize()
+      ..round1Package = ''; // passive receiver
 
-    final req1 = DKGStep1Request()
-      ..userId = userId
-      ..identifier = signingIdThresholdId.serialize()
-      ..round1Package = r1Json1;
+    final reqHw = DKGStep1Request()
+      ..userId = tempUserId
+      ..identifier = hwIdentifier.serialize()
+      ..round1Package = hwR1Json;
 
-    final req2 = DKGStep1Request()
-      ..userId = userId
-      ..identifier = recoveryIdThresholdId.serialize()
-      ..round1Package = r1Json2;
-
-    final step1Futures =
-        await Future.wait([_stub.dKGStep1(req1), _stub.dKGStep1(req2)]);
+    final step1Futures = await Future.wait(
+        [_stub.dKGStep1(reqWallet), _stub.dKGStep1(reqHw)]);
     final step1Resp = step1Futures[0];
 
-    // Trigger Step 2 on server
-    await _stub.dKGStep2(DKGStep2Request()..userId = userId);
+    // 4. Trigger Step 2 on server (server computes round2)
+    await _stub.dKGStep2(DKGStep2Request()..userId = tempUserId);
 
-    // Parse R1 packages for both identities
-    final round1PkgsMap1 = <threshold.Identifier, threshold.Round1Package>{};
-    final round1PkgsMap2 = <threshold.Identifier, threshold.Round1Package>{};
+    // 5. Parse dealer R1 packages (for HW signer and wallet)
+    final dealerR1ForHw = <threshold.Identifier, threshold.Round1Package>{};
+    final dealerR1ForWallet = <threshold.Identifier, threshold.Round1Package>{};
 
     step1Resp.round1Packages.forEach((k, v) {
-      if (v.isEmpty) {
-        throw FormatException('Empty round1 package for key $k');
-      }
+      if (v.isEmpty) return; // skip passive receiver entries
       final id = threshold.Identifier(BigInt.parse(k, radix: 16));
       final pkg = threshold.Round1Package.fromJson(jsonDecode(v));
-      if (id != signingIdThresholdId) round1PkgsMap1[id] = pkg;
-      if (id != recoveryIdThresholdId) round1PkgsMap2[id] = pkg;
+      // HW signer needs all other dealers' R1 (= server's)
+      if (id != hwIdentifier) dealerR1ForHw[id] = pkg;
+      // Wallet needs all dealers' R1 (= HW signer + server)
+      dealerR1ForWallet[id] = pkg;
     });
 
-    // 4. Compute shares: signing identity locally, recovery via hardware signer
-    final (r2Sec1, sharesFrom1) = threshold.dkgPart2(r1Sec1, round1PkgsMap1);
-    final sharesFrom2 = await signer.dkgRound2(round1PkgsMap2);
+    // 6. HW signer computes shares for server + wallet
+    final sharesFromHw = await signer.dkgRound2(
+      dealerR1ForHw,
+      receiverIdentifiers: [walletIdentifier],
+    );
 
-    // 5. Send shares to server
-    final req3_1 = DKGStep3Request()
-      ..userId = userId
-      ..identifier = threshold.bigIntToBytes(signingIdThresholdId.toScalar())
-      ..round2PackagesForOthers.addAll(_buildSharesMap(sharesFrom1));
+    // 7. Send Round2 packages to server
+    //    - HW signer: actual shares for others
+    //    - Wallet: empty (passive receiver)
+    final reqStep3Hw = DKGStep3Request()
+      ..userId = tempUserId
+      ..identifier = threshold.bigIntToBytes(hwIdentifier.toScalar())
+      ..round2PackagesForOthers.addAll(_buildSharesMap(sharesFromHw));
 
-    final req3_2 = DKGStep3Request()
-      ..userId = userId
-      ..identifier = threshold.bigIntToBytes(recoveryIdThresholdId.toScalar())
-      ..round2PackagesForOthers.addAll(_buildSharesMap(sharesFrom2));
+    final reqStep3Wallet = DKGStep3Request()
+      ..userId = tempUserId
+      ..identifier = threshold.bigIntToBytes(walletIdentifier.toScalar());
+    // wallet sends no round2 packages (passive receiver)
 
-    final step3Futures =
-        await Future.wait([_stub.dKGStep3(req3_1), _stub.dKGStep3(req3_2)]);
+    final step3Futures = await Future.wait(
+        [_stub.dKGStep3(reqStep3Wallet), _stub.dKGStep3(reqStep3Hw)]);
 
-    final sharesForMe1 = _parseShares(step3Futures[0].round2PackagesForMe);
-    final sharesForMe2 = _parseShares(step3Futures[1].round2PackagesForMe);
+    // 8. Wallet receives shares from dealers (HW signer + server)
+    final sharesForWallet = _parseShares(step3Futures[0].round2PackagesForMe);
+    final sharesForHw = _parseShares(step3Futures[1].round2PackagesForMe);
 
-    // 6. Finalize signing identity locally
-    final (keyPkg1, pubKeyPkg1) =
-        threshold.dkgPart3(r1Sec1, r2Sec1, round1PkgsMap1, sharesForMe1);
+    // 9. Wallet finalizes as passive receiver
+    final allParticipantIds = <threshold.Identifier>[
+      ...dealerR1ForWallet.keys,
+      walletIdentifier,
+    ];
+    final (walletKeyPkg, pubKeyPkg) = threshold.dkgPart3Receive(
+      walletIdentifier,
+      dealerR1ForWallet,
+      sharesForWallet,
+      _minSigners,
+      _maxSigners,
+      allParticipantIds,
+    );
 
-    // 7. Hardware signer finalizes recovery identity (stores key internally)
-    final dkgResult = await signer.dkgRound3(round1PkgsMap2, sharesForMe2);
+    // 10. HW signer finalizes (stores key internally)
+    final dkgResult = await signer.dkgRound3(
+      dealerR1ForHw,
+      sharesForHw,
+      receiverIdentifiers: [walletIdentifier],
+    );
 
-    // 8. Store policies
+    // 11. Wallet's DKG secret share becomes the auth key
+    _signingSecret = threshold.SecretKey(walletKeyPkg.secretShare);
+    _userId = threshold
+        .elemSerializeCompressed(walletKeyPkg.verifyingShare)
+        .toList();
+    _recoveryId = hwVerifyingKey.toList();
+
+    // 12. Store policies
     _normalPolicy = SpendingPolicy(
         id: "normal_policy_id",
-        keyPackage: keyPkg1,
-        publicKeyPackage: pubKeyPkg1);
+        keyPackage: walletKeyPkg,
+        publicKeyPackage: pubKeyPkg);
 
     // Recovery policy: secret share stays on hardware signer (store zero locally)
     final recoveryVerifyingShare =
-        pubKeyPkg1.verifyingShares[dkgResult.identifier];
+        pubKeyPkg.verifyingShares[dkgResult.identifier];
     if (recoveryVerifyingShare == null) {
       throw StateError("Recovery identifier not found in public key package");
     }
@@ -298,16 +322,15 @@ class MpcClient {
       dkgResult.identifier,
       BigInt.zero, // secret stays on hardware signer
       recoveryVerifyingShare,
-      pubKeyPkg1.verifyingKey,
+      pubKeyPkg.verifyingKey,
       _minSigners,
     );
 
     _recoveryPolicy = RecoveryPolicy(
         id: "recovery_policy_id",
         keyPackage: recoveryKeyPkg,
-        publicKeyPackage: pubKeyPkg1);
+        publicKeyPackage: pubKeyPkg);
 
-    _userId = userId.toList();
     _authHelper = ClientAuthHelper.fromSigningSecret(_signingSecret!, _userId!);
 
     await _saveState();

--- a/client/lib/hardware_signer.dart
+++ b/client/lib/hardware_signer.dart
@@ -59,15 +59,20 @@ abstract class HardwareSignerInterface {
   Future<DkgInitResult> dkgInit(int maxSigners, int minSigners);
 
   /// DKG round 2: verify others' Round1Packages, compute shares.
+  /// [receiverIdentifiers] are passive participants who get shares but
+  /// don't contribute a secret polynomial.
   Future<Map<Identifier, Round2Package>> dkgRound2(
-    Map<Identifier, Round1Package> othersRound1,
-  );
+    Map<Identifier, Round1Package> othersRound1, {
+    List<Identifier> receiverIdentifiers = const [],
+  });
 
   /// DKG round 3: verify received shares, compute final key package on device.
+  /// [receiverIdentifiers] are passive participants included in the PKP.
   Future<DkgFinalResult> dkgRound3(
     Map<Identifier, Round1Package> round1Pkgs,
-    Map<Identifier, Round2Package> round2Pkgs,
-  );
+    Map<Identifier, Round2Package> round2Pkgs, {
+    List<Identifier> receiverIdentifiers = const [],
+  });
 
   /// Generate a signing nonce (one-time use).
   Future<frost_comm.SigningCommitments> generateNonce();
@@ -205,18 +210,26 @@ class TcpHardwareSigner implements HardwareSignerInterface {
 
   @override
   Future<Map<Identifier, Round2Package>> dkgRound2(
-    Map<Identifier, Round1Package> othersRound1,
-  ) async {
+    Map<Identifier, Round1Package> othersRound1, {
+    List<Identifier> receiverIdentifiers = const [],
+  }) async {
     final r1Map = <String, dynamic>{};
     for (final entry in othersRound1.entries) {
       final idHex = hex.encode(entry.key.serialize());
       r1Map[idHex] = entry.value.toJson();
     }
 
-    final resp = await _sendCommand({
+    final cmd = <String, dynamic>{
       'cmd': 'dkg_round2',
       'round1_packages': r1Map,
-    });
+    };
+    if (receiverIdentifiers.isNotEmpty) {
+      cmd['receiver_identifiers'] = receiverIdentifiers
+          .map((id) => hex.encode(id.serialize()))
+          .toList();
+    }
+
+    final resp = await _sendCommand(cmd);
 
     final r2Map = resp['round2_packages'] as Map<String, dynamic>;
     final result = <Identifier, Round2Package>{};
@@ -238,8 +251,9 @@ class TcpHardwareSigner implements HardwareSignerInterface {
   @override
   Future<DkgFinalResult> dkgRound3(
     Map<Identifier, Round1Package> round1Pkgs,
-    Map<Identifier, Round2Package> round2Pkgs,
-  ) async {
+    Map<Identifier, Round2Package> round2Pkgs, {
+    List<Identifier> receiverIdentifiers = const [],
+  }) async {
     final r1Map = <String, dynamic>{};
     for (final entry in round1Pkgs.entries) {
       final idHex = hex.encode(entry.key.serialize());
@@ -252,11 +266,18 @@ class TcpHardwareSigner implements HardwareSignerInterface {
       r2Map[idHex] = entry.value.toJson();
     }
 
-    final resp = await _sendCommand({
+    final cmd = <String, dynamic>{
       'cmd': 'dkg_round3',
       'round1_packages': r1Map,
       'round2_packages': r2Map,
-    });
+    };
+    if (receiverIdentifiers.isNotEmpty) {
+      cmd['receiver_identifiers'] = receiverIdentifiers
+          .map((id) => hex.encode(id.serialize()))
+          .toList();
+    }
+
+    final resp = await _sendCommand(cmd);
 
     final idHex = resp['identifier_hex'] as String;
     final idBytes = Uint8List.fromList(hex.decode(idHex));

--- a/pico-signer/src/handler.rs
+++ b/pico-signer/src/handler.rs
@@ -68,11 +68,14 @@ impl SignerState {
                 max_signers,
                 min_signers,
             } => self.handle_dkg_init(max_signers, min_signers),
-            Request::DkgRound2 { round1_packages } => self.handle_dkg_round2(round1_packages),
+            Request::DkgRound2 { round1_packages, receiver_identifiers } => {
+                self.handle_dkg_round2(round1_packages, receiver_identifiers)
+            }
             Request::DkgRound3 {
                 round1_packages,
                 round2_packages,
-            } => self.handle_dkg_round3(round1_packages, round2_packages),
+                receiver_identifiers,
+            } => self.handle_dkg_round3(round1_packages, round2_packages, receiver_identifiers),
             Request::GenerateNonce => self.handle_generate_nonce(),
             Request::Sign {
                 message_hex,
@@ -114,6 +117,7 @@ impl SignerState {
     fn handle_dkg_round2(
         &mut self,
         round1_packages: BTreeMap<String, serde_json::Value>,
+        receiver_identifier_hexes: Vec<String>,
     ) -> Response {
         let r1_secret = match &self.r1_secret {
             Some(s) => s,
@@ -141,7 +145,15 @@ impl SignerState {
             r1_pkgs.insert(id, pkg);
         }
 
-        match dkg::dkg_part2(r1_secret, &r1_pkgs) {
+        let mut receiver_ids = Vec::new();
+        for hex_str in &receiver_identifier_hexes {
+            match parse_identifier(hex_str) {
+                Ok(id) => receiver_ids.push(id),
+                Err(e) => return Response::Error { error: e },
+            }
+        }
+
+        match dkg::dkg_part2(r1_secret, &r1_pkgs, &receiver_ids) {
             Ok((r2_secret, r2_out)) => {
                 let mut r2_map: BTreeMap<String, serde_json::Value> = BTreeMap::new();
                 for (id, pkg) in &r2_out {
@@ -165,6 +177,7 @@ impl SignerState {
         &mut self,
         round1_packages: BTreeMap<String, serde_json::Value>,
         round2_packages: BTreeMap<String, serde_json::Value>,
+        receiver_identifier_hexes: Vec<String>,
     ) -> Response {
         let r1_secret = match &self.r1_secret {
             Some(s) => s,
@@ -217,7 +230,15 @@ impl SignerState {
             r2_pkgs.insert(id, pkg);
         }
 
-        match dkg::dkg_part3(r1_secret, r2_secret, &r1_pkgs, &r2_pkgs) {
+        let mut receiver_ids = Vec::new();
+        for hex_str in &receiver_identifier_hexes {
+            match parse_identifier(hex_str) {
+                Ok(id) => receiver_ids.push(id),
+                Err(e) => return Response::Error { error: e },
+            }
+        }
+
+        match dkg::dkg_part3(r1_secret, r2_secret, &r1_pkgs, &r2_pkgs, &receiver_ids) {
             Ok((kp, pkp)) => {
                 let id_hex = hex_encode(&kp.identifier.serialize());
                 let pk_hex = hex_encode(&pkp.verifying_key.serialize());

--- a/pico-signer/src/protocol.rs
+++ b/pico-signer/src/protocol.rs
@@ -24,12 +24,16 @@ pub enum Request {
     #[serde(rename = "dkg_round2")]
     DkgRound2 {
         round1_packages: BTreeMap<String, serde_json::Value>,
+        #[serde(default)]
+        receiver_identifiers: alloc::vec::Vec<String>,
     },
 
     #[serde(rename = "dkg_round3")]
     DkgRound3 {
         round1_packages: BTreeMap<String, serde_json::Value>,
         round2_packages: BTreeMap<String, serde_json::Value>,
+        #[serde(default)]
+        receiver_identifiers: alloc::vec::Vec<String>,
     },
 
     #[serde(rename = "generate_nonce")]

--- a/server/lib/server.dart
+++ b/server/lib/server.dart
@@ -151,13 +151,15 @@ class MPCWalletService extends MPCWalletServiceBase {
   }
 
   Future<PolicyState> _newPolicyState(
-      String userId, String recoveryId, NormalPolicy policy) async {
+      String userId, String recoveryId, NormalPolicy policy,
+      {threshold.Identifier? userSigningIdentifier}) async {
     return await _policyLock.synchronized(() {
       if (_policies.containsKey(userId)) {
         //remove existing
         _policies.remove(userId);
       }
-      _policies[userId] = PolicyState(userId, recoveryId, policy);
+      _policies[userId] = PolicyState(userId, recoveryId, policy,
+          userSigningIdentifier: userSigningIdentifier);
       _log.info('[$userId] New Policy state created');
       return _policies[userId]!;
     });
@@ -209,11 +211,6 @@ class MPCWalletService extends MPCWalletServiceBase {
     };
   }
 
-  static String _userIdFromVerifyingKey(threshold.VerifyingKey verifyingKey) {
-    final bytes = threshold.elemSerializeCompressed(verifyingKey.E);
-    return hex.encode(bytes);
-  }
-
   // --- DKG ---
   @override
   Future<DKGStep1Response> dKGStep1(
@@ -226,10 +223,17 @@ class MPCWalletService extends MPCWalletServiceBase {
     try {
       final identifier = threshold.Identifier.deserialize(
           Uint8List.fromList(request.identifier));
-      _log.info(
-          '[$userIdHex] DKGStep1: Received PubPackage from ${hex.encode(userId)}');
 
-      session.round1Packages[identifier] = request.round1Package;
+      // Empty round1_package means this participant is a passive receiver
+      if (request.round1Package.isEmpty) {
+        _log.info(
+            '[$userIdHex] DKGStep1: Registered passive receiver ${_idToString(identifier)}');
+        session.receiverIdentifiers.add(identifier);
+      } else {
+        _log.info(
+            '[$userIdHex] DKGStep1: Received PubPackage from ${_idToString(identifier)}');
+        session.round1Packages[identifier] = request.round1Package;
+      }
 
       // Server Init for this session
       if (session.serverRound1SecretPackage == null) {
@@ -251,7 +255,9 @@ class MPCWalletService extends MPCWalletServiceBase {
             jsonEncode(r1Public.toJson());
       }
 
-      if (session.round1Packages.length == totalParticipants) {
+      if (session.round1Packages.length +
+              session.receiverIdentifiers.length ==
+          totalParticipants) {
         if (!session.completerStep1.isCompleted)
           session.completerStep1.complete();
       } else {
@@ -283,11 +289,10 @@ class MPCWalletService extends MPCWalletServiceBase {
 
       if (session.dkgRound2PackagesLocal.isEmpty) {
         _log.info('[$userIdHex] DKGStep2: Server computing shares...');
+        final serverIdentifier = threshold.Identifier.derive(session.serverId!);
         final round1Pkgs = <threshold.Identifier, threshold.Round1Package>{};
         session.round1Packages.forEach((k, v) {
-          final serverIdenfier = threshold.Identifier.derive(session.serverId!);
-
-          if (k != serverIdenfier) {
+          if (k != serverIdentifier) {
             round1Pkgs[k] = threshold.Round1Package.fromJson(jsonDecode(v));
           }
         });
@@ -296,8 +301,11 @@ class MPCWalletService extends MPCWalletServiceBase {
           throw StateError('Server secrets missing for session $userIdHex');
         }
 
-        final (serverRound2Secret, serverRound2Pkgs) =
-            threshold.dkgPart2(session.serverRound1SecretPackage!, round1Pkgs);
+        final (serverRound2Secret, serverRound2Pkgs) = threshold.dkgPart2(
+          session.serverRound1SecretPackage!,
+          round1Pkgs,
+          receiverIdentifiers: session.receiverIdentifiers.toList(),
+        );
 
         session.serverRound2Secret = serverRound2Secret;
         session.dkgRound2PackagesLocal.addAll(serverRound2Pkgs);
@@ -372,18 +380,17 @@ class MPCWalletService extends MPCWalletServiceBase {
       if (session.completerStep3.isCompleted) {
         _log.info('[$userIdHex] DKGStep3: Server computing KeyPackage...');
 
-        final userSigningIdentifier =
-            threshold.Identifier.derive(Uint8List.fromList(userId));
-
         Uint8List? userRecoveryIdentifier;
 
+        // Build round1 packages from other dealers (not server, not receivers)
         final allRound1Pkgs = <threshold.Identifier, threshold.Round1Package>{};
         session.round1Packages.forEach((k, v) {
           final decodedPkg = threshold.Round1Package.fromJson(jsonDecode(v));
           if (k != serverIdentifier) {
             allRound1Pkgs[k] = decodedPkg;
 
-            if (k != userSigningIdentifier && userRecoveryIdentifier == null) {
+            // First non-server dealer is the recovery identity (HW signer)
+            if (userRecoveryIdentifier == null) {
               userRecoveryIdentifier =
                   threshold.elemSerializeCompressed(decodedPkg.verifyingKey.E);
             }
@@ -395,10 +402,12 @@ class MPCWalletService extends MPCWalletServiceBase {
         allReceivedSharesPoints.addAll(session.dkgRound2PackagesReceived);
 
         final (keyPkg, pubKeyPkg) = threshold.dkgPart3(
-            session.serverRound1SecretPackage!,
-            session.serverRound2Secret!,
-            allRound1Pkgs,
-            allReceivedSharesPoints);
+          session.serverRound1SecretPackage!,
+          session.serverRound2Secret!,
+          allRound1Pkgs,
+          allReceivedSharesPoints,
+          receiverIdentifiers: session.receiverIdentifiers.toList(),
+        );
 
         final normalPolicy = NormalPolicy(
           id: "normal policies",
@@ -406,18 +415,35 @@ class MPCWalletService extends MPCWalletServiceBase {
           publicKeyPackage: pubKeyPkg,
         );
 
+        // Determine the wallet's userId and signing identifier.
+        // If there are passive receivers, the wallet's userId is its
+        // verifying share (compressed point). Otherwise, fall back to
+        // the DKG session key (backward-compatible with old 3-dealer DKG).
+        String policyUserId;
+        threshold.Identifier? walletSigningIdentifier;
+        if (session.receiverIdentifiers.isNotEmpty) {
+          final walletId = session.receiverIdentifiers.first;
+          walletSigningIdentifier = walletId;
+          final walletVs = pubKeyPkg.verifyingShares[walletId]!;
+          policyUserId =
+              hex.encode(threshold.elemSerializeCompressed(walletVs));
+        } else {
+          policyUserId = userIdHex;
+        }
+
         // fresh policy state
         final userRecoveryIdHex = hex.encode(userRecoveryIdentifier!);
-        final policyState =
-            await _newPolicyState(userIdHex, userRecoveryIdHex, normalPolicy);
-        _policies[userIdHex] = policyState;
+        final policyState = await _newPolicyState(
+            policyUserId, userRecoveryIdHex, normalPolicy,
+            userSigningIdentifier: walletSigningIdentifier);
+        _policies[policyUserId] = policyState;
 
         _log.info('[$userId] DKG Complete. PK: ${pubKeyPkg.verifyingKey.E}');
 
         // Persistence
         try {
           await policyStore.savePolicy(
-              userIdHex, jsonEncode(policyState.toJson()));
+              policyUserId, jsonEncode(policyState.toJson()));
           await dkgStore.saveSession(userIdHex, jsonEncode(session.toJson()));
           _log.info('[$userId] Saved DKG completion state.');
         } catch (e) {
@@ -543,7 +569,7 @@ class MPCWalletService extends MPCWalletServiceBase {
       final policyState = await _getPolicyState(userIdHex);
       _log.info('[$userId] SignStep1: Received from ${userIdHex}');
 
-      final userIdentifier =
+      final userIdentifier = policyState.userSigningIdentifier ??
           threshold.Identifier.derive(Uint8List.fromList(userId));
       var serverKeyPackage = policyState.normalPolicy.keyPackage;
 
@@ -644,7 +670,7 @@ class MPCWalletService extends MPCWalletServiceBase {
     try {
       final policyState = await _getPolicyState(userIdHex);
 
-      final userIdentifier =
+      final userIdentifier = policyState.userSigningIdentifier ??
           threshold.Identifier.derive(Uint8List.fromList(userId));
 
       var serverKeyPackage = policyState.normalPolicy.keyPackage;

--- a/server/lib/state.dart
+++ b/server/lib/state.dart
@@ -24,6 +24,7 @@ class DKGSessionState {
 
   // DKG Data (Persisted)
   final round1Packages = <threshold.Identifier, String>{}; // Identifier -> JSON
+  final receiverIdentifiers = <threshold.Identifier>{}; // passive receivers
 
   Uint8List? serverId;
 
@@ -71,6 +72,7 @@ class DKGSessionState {
     completerStep2 = Completer<void>();
     completerStep3 = Completer<void>();
     round1Packages.clear();
+    receiverIdentifiers.clear();
     serverInternalSecret = null;
     serverRound1SecretPackage = null;
     serverRound2Secret = null;
@@ -84,6 +86,10 @@ class PolicyState {
   final String userId;
   final String recoveryId;
 
+  // The wallet's DKG identifier (may differ from Identifier.derive(userId)
+  // when the wallet is a passive receiver in DKG).
+  threshold.Identifier? userSigningIdentifier;
+
   // normal Policy
   final NormalPolicy normalPolicy;
   // protected Policies
@@ -91,12 +97,16 @@ class PolicyState {
 
   final spendingHistory = <SpendingEntry>[];
 
-  PolicyState(this.userId, this.recoveryId, this.normalPolicy);
+  PolicyState(this.userId, this.recoveryId, this.normalPolicy,
+      {this.userSigningIdentifier});
 
   Map<String, dynamic> toJson() {
     return {
       'userId': userId,
       'recoveryId': recoveryId,
+      if (userSigningIdentifier != null)
+        'userSigningIdentifier':
+            hex.encode(userSigningIdentifier!.serialize()),
       'normalPolicy': normalPolicy.toJson(),
       'protectedPolicies':
           protectedPolicies.map((k, v) => MapEntry(k, v.toJson())),
@@ -105,8 +115,14 @@ class PolicyState {
   }
 
   static PolicyState fromJson(Map<String, dynamic> json) {
+    threshold.Identifier? signingId;
+    if (json['userSigningIdentifier'] != null) {
+      signingId = threshold.Identifier.deserialize(
+          Uint8List.fromList(hex.decode(json['userSigningIdentifier'])));
+    }
     final s = PolicyState(json['userId'], json['recoveryId'],
-        NormalPolicy.fromJson(json['normalPolicy']));
+        NormalPolicy.fromJson(json['normalPolicy']),
+        userSigningIdentifier: signingId);
 
     if (json['protectedPolicies'] != null) {
       final Map<String, dynamic> map = json['protectedPolicies'];

--- a/signer-server/src/handler.rs
+++ b/signer-server/src/handler.rs
@@ -40,11 +40,14 @@ impl SignerState {
                 max_signers,
                 min_signers,
             } => self.handle_dkg_init(max_signers, min_signers),
-            Request::DkgRound2 { round1_packages } => self.handle_dkg_round2(round1_packages),
+            Request::DkgRound2 { round1_packages, receiver_identifiers } => {
+                self.handle_dkg_round2(round1_packages, receiver_identifiers)
+            }
             Request::DkgRound3 {
                 round1_packages,
                 round2_packages,
-            } => self.handle_dkg_round3(round1_packages, round2_packages),
+                receiver_identifiers,
+            } => self.handle_dkg_round3(round1_packages, round2_packages, receiver_identifiers),
             Request::GenerateNonce => self.handle_generate_nonce(),
             Request::Sign {
                 message_hex,
@@ -89,6 +92,7 @@ impl SignerState {
     fn handle_dkg_round2(
         &mut self,
         round1_packages: HashMap<String, serde_json::Value>,
+        receiver_identifier_hexes: Vec<String>,
     ) -> Response {
         let r1_secret = match &self.r1_secret {
             Some(s) => s,
@@ -117,7 +121,15 @@ impl SignerState {
             r1_pkgs.insert(id, pkg);
         }
 
-        match dkg::dkg_part2(r1_secret, &r1_pkgs) {
+        let mut receiver_ids = Vec::new();
+        for hex_str in &receiver_identifier_hexes {
+            match parse_identifier(hex_str) {
+                Ok(id) => receiver_ids.push(id),
+                Err(e) => return Response::Error { error: e },
+            }
+        }
+
+        match dkg::dkg_part2(r1_secret, &r1_pkgs, &receiver_ids) {
             Ok((r2_secret, r2_out)) => {
                 let mut r2_map: HashMap<String, serde_json::Value> = HashMap::new();
                 for (id, pkg) in &r2_out {
@@ -141,6 +153,7 @@ impl SignerState {
         &mut self,
         round1_packages: HashMap<String, serde_json::Value>,
         round2_packages: HashMap<String, serde_json::Value>,
+        receiver_identifier_hexes: Vec<String>,
     ) -> Response {
         let r1_secret = match &self.r1_secret {
             Some(s) => s,
@@ -195,7 +208,15 @@ impl SignerState {
             r2_pkgs.insert(id, pkg);
         }
 
-        match dkg::dkg_part3(r1_secret, r2_secret, &r1_pkgs, &r2_pkgs) {
+        let mut receiver_ids = Vec::new();
+        for hex_str in &receiver_identifier_hexes {
+            match parse_identifier(hex_str) {
+                Ok(id) => receiver_ids.push(id),
+                Err(e) => return Response::Error { error: e },
+            }
+        }
+
+        match dkg::dkg_part3(r1_secret, r2_secret, &r1_pkgs, &r2_pkgs, &receiver_ids) {
             Ok((kp, pkp)) => {
                 let id_hex = hex_encode(&kp.identifier.serialize());
                 let pk_hex = hex_encode(&pkp.verifying_key.serialize());

--- a/signer-server/src/protocol.rs
+++ b/signer-server/src/protocol.rs
@@ -18,12 +18,16 @@ pub enum Request {
     DkgRound2 {
         /// Keyed by identifier hex, value is Round1Package JSON
         round1_packages: HashMap<String, serde_json::Value>,
+        #[serde(default)]
+        receiver_identifiers: Vec<String>,
     },
 
     #[serde(rename = "dkg_round3")]
     DkgRound3 {
         round1_packages: HashMap<String, serde_json::Value>,
         round2_packages: HashMap<String, serde_json::Value>,
+        #[serde(default)]
+        receiver_identifiers: Vec<String>,
     },
 
     #[serde(rename = "generate_nonce")]

--- a/threshold-rs/src/dkg.rs
+++ b/threshold-rs/src/dkg.rs
@@ -202,13 +202,15 @@ pub fn dkg_part1(
 /// DKG round 2: verify others' round 1 packages and compute shares for each.
 ///
 /// - `secret_pkg`: our round 1 secret package.
-/// - `round1_pkgs`: round 1 packages from all other participants (keyed by their identifier).
+/// - `round1_pkgs`: round 1 packages from all other *dealer* participants.
+/// - `receiver_identifiers`: identifiers of passive receivers (no round 1 package).
 /// - Returns `(Round2SecretPackage, Map<Identifier, Round2Package>)`.
 pub fn dkg_part2(
     secret_pkg: &Round1SecretPackage,
     round1_pkgs: &BTreeMap<Identifier, Round1Package>,
+    receiver_identifiers: &[Identifier],
 ) -> Result<(Round2SecretPackage, BTreeMap<Identifier, Round2Package>), Error> {
-    if round1_pkgs.len() != secret_pkg.max_signers - 1 {
+    if round1_pkgs.len() + receiver_identifiers.len() != secret_pkg.max_signers - 1 {
         return Err(Error::IncorrectNumberOfPackages);
     }
     for pkg in round1_pkgs.values() {
@@ -218,12 +220,20 @@ pub fn dkg_part2(
     }
 
     let mut out = BTreeMap::new();
+
+    // Compute shares for other dealers (verify proofs)
     for (sender_id, pkg) in round1_pkgs {
         let vk = pkg.commitment.to_verifying_key();
         verify_proof_of_knowledge(sender_id, &vk, &pkg.proof_of_knowledge)?;
 
         let share = polynomial::evaluate_polynomial(sender_id, &secret_pkg.coefficients);
         out.insert(sender_id.clone(), Round2Package { secret_share: share });
+    }
+
+    // Compute shares for passive receivers (no proof to verify)
+    for receiver_id in receiver_identifiers {
+        let share = polynomial::evaluate_polynomial(receiver_id, &secret_pkg.coefficients);
+        out.insert(receiver_id.clone(), Round2Package { secret_share: share });
     }
 
     let fii = polynomial::evaluate_polynomial(
@@ -251,16 +261,18 @@ pub fn dkg_part2(
 ///
 /// - `_r1_secret`: round 1 secret package (kept for API compatibility with Dart).
 /// - `r2_secret`: round 2 secret package.
-/// - `round1_pkgs`: others' round 1 packages.
-/// - `round2_pkgs`: others' round 2 packages (shares addressed to us).
+/// - `round1_pkgs`: other dealers' round 1 packages.
+/// - `round2_pkgs`: other dealers' round 2 packages (shares addressed to us).
+/// - `receiver_identifiers`: identifiers of passive receivers (included in PKP).
 /// - Returns `(KeyPackage, PublicKeyPackage)` both normalized to even Y.
 pub fn dkg_part3(
     _r1_secret: &Round1SecretPackage,
     r2_secret: &Round2SecretPackage,
     round1_pkgs: &BTreeMap<Identifier, Round1Package>,
     round2_pkgs: &BTreeMap<Identifier, Round2Package>,
+    receiver_identifiers: &[Identifier],
 ) -> Result<(crate::keys::KeyPackage, PublicKeyPackage), Error> {
-    if round1_pkgs.len() != r2_secret.max_signers - 1 {
+    if round1_pkgs.len() + receiver_identifiers.len() != r2_secret.max_signers - 1 {
         return Err(Error::IncorrectNumberOfPackages);
     }
     if round1_pkgs.len() != round2_pkgs.len() {
@@ -294,14 +306,21 @@ pub fn dkg_part3(
     let secret_share = si;
     let verifying_share = point::base_mul(&secret_share);
 
-    // Build commitment map for PublicKeyPackage
+    // Build commitment map from dealer round 1 packages
     let mut commit_map: BTreeMap<Identifier, VssCommitment> = BTreeMap::new();
     for (id, pkg) in round1_pkgs {
         commit_map.insert(id.clone(), pkg.commitment.clone());
     }
     commit_map.insert(r2_secret.identifier.clone(), r2_secret.commitment.clone());
 
-    let public_key_package = pkp_from_dkg_commitments(&commit_map)?;
+    // Build PublicKeyPackage with ALL participant IDs (dealers + receivers)
+    let group = vss::sum_commitments(&commit_map.values().cloned().collect::<Vec<_>>())?;
+    let mut all_ids: Vec<Identifier> = commit_map.keys().cloned().collect();
+    for rid in receiver_identifiers {
+        all_ids.push(rid.clone());
+    }
+    all_ids.sort();
+    let public_key_package = pkp_from_commitment(&all_ids, &group);
 
     let key_package = crate::keys::KeyPackage {
         identifier: r2_secret.identifier.clone(),
@@ -314,19 +333,74 @@ pub fn dkg_part3(
     Ok((key_package.into_even_y(), public_key_package.into_even_y()))
 }
 
+/// DKG Part 3 for a passive receiver (no secret polynomial contribution).
+///
+/// The receiver verifies shares from each dealer against their commitments,
+/// accumulates the shares (no self-share), and derives its KeyPackage and
+/// the shared PublicKeyPackage.
+pub fn dkg_part3_receive(
+    my_identifier: &Identifier,
+    dealer_round1_pkgs: &BTreeMap<Identifier, Round1Package>,
+    shares_for_me: &BTreeMap<Identifier, Round2Package>,
+    min_signers: usize,
+    max_signers: usize,
+    all_participant_identifiers: &[Identifier],
+) -> Result<(crate::keys::KeyPackage, PublicKeyPackage), Error> {
+    if dealer_round1_pkgs.len() != shares_for_me.len() {
+        return Err(Error::IncorrectNumberOfPackages);
+    }
+    for id in dealer_round1_pkgs.keys() {
+        if !shares_for_me.contains_key(id) {
+            return Err(Error::IncorrectPackageMapping);
+        }
+    }
+
+    // Verify each dealer's share against their commitment, then accumulate
+    let mut si = Scalar::ZERO;
+    for (dealer_id, pkg2) in shares_for_me {
+        let r1 = dealer_round1_pkgs
+            .get(dealer_id)
+            .ok_or(Error::UnknownIdentifier)?;
+
+        let share_point = point::base_mul(&pkg2.secret_share);
+        let expected = r1.commitment.get_verifying_share(my_identifier);
+        if !point::points_equal(&share_point, &expected) {
+            return Err(Error::InvalidSecretShare);
+        }
+
+        si = si + pkg2.secret_share;
+    }
+
+    // Receiver has no self-share
+    let secret_share = si;
+    let verifying_share = point::base_mul(&secret_share);
+
+    // Build PublicKeyPackage from dealer commitments with ALL participant IDs
+    let dealer_commitments: Vec<VssCommitment> = dealer_round1_pkgs
+        .values()
+        .map(|pkg| pkg.commitment.clone())
+        .collect();
+    let group = vss::sum_commitments(&dealer_commitments)?;
+
+    let mut sorted_ids = all_participant_identifiers.to_vec();
+    sorted_ids.sort();
+    let public_key_package = pkp_from_commitment(&sorted_ids, &group);
+
+    let key_package = crate::keys::KeyPackage {
+        identifier: my_identifier.clone(),
+        secret_share,
+        verifying_share,
+        verifying_key: public_key_package.verifying_key.clone(),
+        min_signers,
+    };
+
+    let _ = max_signers; // used for API consistency
+    Ok((key_package.into_even_y(), public_key_package.into_even_y()))
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Build a PublicKeyPackage from the combined DKG commitments.
-fn pkp_from_dkg_commitments(
-    commits: &BTreeMap<Identifier, VssCommitment>,
-) -> Result<PublicKeyPackage, Error> {
-    let ids: Vec<Identifier> = commits.keys().cloned().collect();
-    let list: Vec<VssCommitment> = commits.values().cloned().collect();
-    let group = vss::sum_commitments(&list)?;
-    Ok(pkp_from_commitment(&ids, &group))
-}
 
 /// Build a PublicKeyPackage from a summed commitment and the set of identifiers.
 fn pkp_from_commitment(

--- a/threshold-rs/tests/frost_test.rs
+++ b/threshold-rs/tests/frost_test.rs
@@ -492,7 +492,7 @@ fn run_full_dkg(
             .collect();
 
         let (r2_secret, r2_out) =
-            dkg::dkg_part2(secret_pkg, &others).expect("dkg_part2 failed");
+            dkg::dkg_part2(secret_pkg, &others, &[]).expect("dkg_part2 failed");
 
         r2_secrets.push(r2_secret);
         all_r2_packages.push(r2_out);
@@ -523,7 +523,7 @@ fn run_full_dkg(
         }
 
         let (kp, pkp) =
-            dkg::dkg_part3(&r1_secrets[i], r2_secret, &others_r1, &our_r2)
+            dkg::dkg_part3(&r1_secrets[i], r2_secret, &others_r1, &our_r2, &[])
                 .expect("dkg_part3 failed");
 
         key_packages.push(kp);

--- a/threshold/lib/core/dkg.dart
+++ b/threshold/lib/core/dkg.dart
@@ -335,9 +335,11 @@ SecretShare secretShareFromCoefficients(List<BigInt> coeffs, Identifier peer) {
 
 (Round2SecretPackage, Map<Identifier, Round2Package>) dkgPart2(
   Round1SecretPackage secretPkg,
-  Map<Identifier, Round1Package> round1Pkgs,
-) {
-  if (round1Pkgs.length != secretPkg.maxSigners - 1) {
+  Map<Identifier, Round1Package> round1Pkgs, {
+  List<Identifier> receiverIdentifiers = const [],
+}) {
+  if (round1Pkgs.length + receiverIdentifiers.length !=
+      secretPkg.maxSigners - 1) {
     throw IncorrectNumberOfPackagesException("incorrect number of packages");
   }
   for (final p in round1Pkgs.values) {
@@ -349,6 +351,8 @@ SecretShare secretShareFromCoefficients(List<BigInt> coeffs, Identifier peer) {
   }
 
   final out = <Identifier, Round2Package>{};
+
+  // Compute shares for other dealers (verify proofs)
   for (final entry in round1Pkgs.entries) {
     final senderID = entry.key;
     final pkg = entry.value;
@@ -358,6 +362,13 @@ SecretShare secretShareFromCoefficients(List<BigInt> coeffs, Identifier peer) {
 
     final share = secretShareFromCoefficients(secretPkg.coefficients, senderID);
     out[senderID] = Round2Package(share);
+  }
+
+  // Compute shares for passive receivers (no proof to verify)
+  for (final receiverId in receiverIdentifiers) {
+    final share =
+        secretShareFromCoefficients(secretPkg.coefficients, receiverId);
+    out[receiverId] = Round2Package(share);
   }
 
   final fii = evaluatePolynomial(secretPkg.identifier, secretPkg.coefficients);
@@ -378,9 +389,11 @@ SecretShare secretShareFromCoefficients(List<BigInt> coeffs, Identifier peer) {
   Round1SecretPackage r1Secret,
   Round2SecretPackage r2Secret,
   Map<Identifier, Round1Package> round1Pkgs,
-  Map<Identifier, Round2Package> round2Pkgs,
-) {
-  if (round1Pkgs.length != r2Secret.maxSigners - 1) {
+  Map<Identifier, Round2Package> round2Pkgs, {
+  List<Identifier> receiverIdentifiers = const [],
+}) {
+  if (round1Pkgs.length + receiverIdentifiers.length !=
+      r2Secret.maxSigners - 1) {
     throw IncorrectNumberOfPackagesException("incorrect number of packages");
   }
   if (round1Pkgs.length != round2Pkgs.length) {
@@ -414,13 +427,18 @@ SecretShare secretShareFromCoefficients(List<BigInt> coeffs, Identifier peer) {
 
   final verifyingShare = elemBaseMul(secretShare);
 
+  // Build commitment map from dealer round1 packages
   final commitMap = <Identifier, VerifiableSecretSharingCommitment>{};
   for (final entry in round1Pkgs.entries) {
     commitMap[entry.key] = entry.value.commitment;
   }
   commitMap[r2Secret.identifier] = r2Secret.commitment;
 
-  final publicKeyPackage = pkpFromDkgCommitments(commitMap);
+  // Build PublicKeyPackage with ALL participant IDs (dealers + receivers)
+  final group = sumCommitments(commitMap.values.toList());
+  final allIds = [...commitMap.keys, ...receiverIdentifiers]
+    ..sort((a, b) => a.s.compareTo(b.s));
+  final publicKeyPackage = pkpFromCommitment(allIds, group);
 
   final keyPackage = KeyPackage(
     r2Secret.identifier,
@@ -428,6 +446,71 @@ SecretShare secretShareFromCoefficients(List<BigInt> coeffs, Identifier peer) {
     verifyingShare,
     publicKeyPackage.verifyingKey,
     r2Secret.minSigners,
+  );
+
+  return (keyPackage.intoEvenY(), publicKeyPackage.intoEvenY());
+}
+
+/// DKG Part 3 for a passive receiver (no secret polynomial contribution).
+///
+/// The receiver verifies shares from each dealer against their commitments,
+/// accumulates the shares (no self-share), and derives its KeyPackage and
+/// the shared PublicKeyPackage.
+(KeyPackage, PublicKeyPackage) dkgPart3Receive(
+  Identifier myIdentifier,
+  Map<Identifier, Round1Package> dealerRound1Pkgs,
+  Map<Identifier, Round2Package> sharesForMe,
+  int minSigners,
+  int maxSigners,
+  List<Identifier> allParticipantIdentifiers,
+) {
+  if (dealerRound1Pkgs.length != sharesForMe.length) {
+    throw IncorrectNumberOfPackagesException(
+      "dealer round1 packages and shares must have same length",
+    );
+  }
+  for (final id in dealerRound1Pkgs.keys) {
+    if (!sharesForMe.containsKey(id)) {
+      throw IncorrectPackageException("missing share from dealer $id");
+    }
+  }
+
+  // Verify each dealer's share against their commitment, then accumulate
+  var si = modNZero();
+  for (final entry in sharesForMe.entries) {
+    final dealerId = entry.key;
+    final pkg2 = entry.value;
+
+    final r1 = dealerRound1Pkgs[dealerId]!;
+    final temp = ThresholdShare(
+      myIdentifier,
+      pkg2.secretShare,
+      elemBaseMul(pkg2.secretShare),
+      r1.commitment,
+    );
+    temp.verify();
+    si = (si + pkg2.secretShare);
+  }
+
+  // Receiver has no self-share — secretShare is the sum of received shares
+  final secretShare = si;
+  final verifyingShare = elemBaseMul(secretShare);
+
+  // Build PublicKeyPackage from dealer commitments with ALL participant IDs
+  final dealerCommitments =
+      dealerRound1Pkgs.values.map((pkg) => pkg.commitment).toList();
+  final group = sumCommitments(dealerCommitments);
+
+  final sortedIds = List<Identifier>.from(allParticipantIdentifiers)
+    ..sort((a, b) => a.s.compareTo(b.s));
+  final publicKeyPackage = pkpFromCommitment(sortedIds, group);
+
+  final keyPackage = KeyPackage(
+    myIdentifier,
+    secretShare,
+    verifyingShare,
+    publicKeyPackage.verifyingKey,
+    minSigners,
   );
 
   return (keyPackage.intoEvenY(), publicKeyPackage.intoEvenY());

--- a/threshold/test/dkg_receiver_test.dart
+++ b/threshold/test/dkg_receiver_test.dart
@@ -1,0 +1,215 @@
+import 'dart:typed_data';
+
+import 'package:threshold/threshold.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('2-Dealer DKG with Passive Receiver', () {
+    test('DKG produces matching keys and all 2-of-3 signing works', () {
+      const minSigners = 2;
+      const maxSigners = 3;
+
+      // --- Setup: two dealers generate secrets ---
+      final dealer1Secret = SecretKey(modNRandom());
+      final dealer1Coeffs = generateCoefficients(minSigners - 1);
+      final dealer2Secret = SecretKey(modNRandom());
+      final dealer2Coeffs = generateCoefficients(minSigners - 1);
+
+      // --- Round 1: dealers only ---
+      final (d1R1Sec, d1R1Pub) =
+          dkgPart1(maxSigners, minSigners, dealer1Secret, dealer1Coeffs);
+      final (d2R1Sec, d2R1Pub) =
+          dkgPart1(maxSigners, minSigners, dealer2Secret, dealer2Coeffs);
+
+      // Derive receiver identifier from dealer1's verifying key
+      final d1VkBytes = elemSerializeCompressed(d1R1Pub.verifyingKey.E);
+      final receiverIdInput = Uint8List.fromList(
+        [...'wallet:'.codeUnits, ...d1VkBytes],
+      );
+      final receiverId = Identifier.derive(receiverIdInput);
+
+      final allIds = [d1R1Sec.identifier, d2R1Sec.identifier, receiverId];
+
+      // --- Round 2: dealers compute shares for each other AND receiver ---
+      final (d1R2Sec, d1R2Out) = dkgPart2(
+        d1R1Sec,
+        {d2R1Sec.identifier: d2R1Pub},
+        receiverIdentifiers: [receiverId],
+      );
+      final (d2R2Sec, d2R2Out) = dkgPart2(
+        d2R1Sec,
+        {d1R1Sec.identifier: d1R1Pub},
+        receiverIdentifiers: [receiverId],
+      );
+
+      // --- Round 3: dealers finalize ---
+      final (d1KeyPkg, d1Pkp) = dkgPart3(
+        d1R1Sec,
+        d1R2Sec,
+        {d2R1Sec.identifier: d2R1Pub},
+        {d2R1Sec.identifier: d2R2Out[d1R1Sec.identifier]!},
+        receiverIdentifiers: [receiverId],
+      );
+      final (d2KeyPkg, d2Pkp) = dkgPart3(
+        d2R1Sec,
+        d2R2Sec,
+        {d1R1Sec.identifier: d1R1Pub},
+        {d1R1Sec.identifier: d1R2Out[d2R1Sec.identifier]!},
+        receiverIdentifiers: [receiverId],
+      );
+
+      // --- Round 3 Receive: passive receiver ---
+      final (receiverKeyPkg, receiverPkp) = dkgPart3Receive(
+        receiverId,
+        {
+          d1R1Sec.identifier: d1R1Pub,
+          d2R1Sec.identifier: d2R1Pub,
+        },
+        {
+          d1R1Sec.identifier: d1R2Out[receiverId]!,
+          d2R1Sec.identifier: d2R2Out[receiverId]!,
+        },
+        minSigners,
+        maxSigners,
+        allIds,
+      );
+
+      // --- Verify all 3 got the same public key ---
+      final d1VkHex = elemSerializeCompressed(d1Pkp.verifyingKey.E);
+      final d2VkHex = elemSerializeCompressed(d2Pkp.verifyingKey.E);
+      final rVkHex = elemSerializeCompressed(receiverPkp.verifyingKey.E);
+
+      expect(d1VkHex, equals(d2VkHex),
+          reason: 'Dealer 1 and Dealer 2 public keys must match');
+      expect(d1VkHex, equals(rVkHex),
+          reason: 'Dealer and Receiver public keys must match');
+
+      // --- Verify all 3 PKPs have verifying shares for all IDs ---
+      for (final id in allIds) {
+        expect(d1Pkp.verifyingShares.containsKey(id), isTrue);
+        expect(d2Pkp.verifyingShares.containsKey(id), isTrue);
+        expect(receiverPkp.verifyingShares.containsKey(id), isTrue);
+
+        expect(
+          elemSerializeCompressed(d1Pkp.verifyingShares[id]!),
+          equals(elemSerializeCompressed(d2Pkp.verifyingShares[id]!)),
+        );
+        expect(
+          elemSerializeCompressed(d1Pkp.verifyingShares[id]!),
+          equals(elemSerializeCompressed(receiverPkp.verifyingShares[id]!)),
+        );
+      }
+
+      // --- Verify group key = sum of dealer secrets only ---
+      final n = secp256k1Curve.n;
+      var expectedGroupKey =
+          (dealer1Secret.scalar + dealer2Secret.scalar) % n;
+      final groupPoint = (secp256k1Curve.G * expectedGroupKey)!;
+      if (!groupPoint.y!.toBigInteger()!.isEven) {
+        expectedGroupKey = n - expectedGroupKey;
+      }
+
+      // Reconstruct from all 2-of-3 combinations
+      final shares = {
+        d1KeyPkg.identifier: d1KeyPkg.secretShare,
+        d2KeyPkg.identifier: d2KeyPkg.secretShare,
+        receiverKeyPkg.identifier: receiverKeyPkg.secretShare,
+      };
+      final idList = shares.keys.toList();
+      for (var i = 0; i < idList.length; i++) {
+        for (var j = i + 1; j < idList.length; j++) {
+          final subset = {
+            idList[i]: shares[idList[i]]!,
+            idList[j]: shares[idList[j]]!,
+          };
+          final reconstructed = reconstruct(minSigners, subset);
+          expect(reconstructed.scalar, equals(expectedGroupKey),
+              reason: 'Reconstruction from pair ($i,$j) must match group key');
+        }
+      }
+
+      // --- Sign with dealer1 + receiver ---
+      final message = Uint8List.fromList('2-dealer DKG test'.codeUnits);
+
+      _verifySigningPair(
+        d1KeyPkg, receiverKeyPkg, d1Pkp, message, 'dealer1+receiver');
+
+      // --- Sign with dealer2 + receiver ---
+      _verifySigningPair(
+        d2KeyPkg, receiverKeyPkg, d2Pkp, message, 'dealer2+receiver');
+
+      // --- Sign with dealer1 + dealer2 ---
+      _verifySigningPair(
+        d1KeyPkg, d2KeyPkg, d1Pkp, message, 'dealer1+dealer2');
+    });
+
+    test('receiver share verification rejects tampered share', () {
+      const minSigners = 2;
+      const maxSigners = 3;
+
+      final (d1R1Sec, d1R1Pub) = dkgPart1(
+        maxSigners, minSigners, SecretKey(modNRandom()),
+        generateCoefficients(minSigners - 1));
+      final (d2R1Sec, d2R1Pub) = dkgPart1(
+        maxSigners, minSigners, SecretKey(modNRandom()),
+        generateCoefficients(minSigners - 1));
+
+      final receiverId = identifierFromUint16(42);
+
+      final (_, d1R2Out) = dkgPart2(
+        d1R1Sec,
+        {d2R1Sec.identifier: d2R1Pub},
+        receiverIdentifiers: [receiverId],
+      );
+      final (_, d2R2Out) = dkgPart2(
+        d2R1Sec,
+        {d1R1Sec.identifier: d1R1Pub},
+        receiverIdentifiers: [receiverId],
+      );
+
+      // Tamper with dealer1's share for receiver
+      final tamperedShare = Round2Package(
+        d1R2Out[receiverId]!.secretShare + BigInt.one,
+      );
+
+      expect(
+        () => dkgPart3Receive(
+          receiverId,
+          {d1R1Sec.identifier: d1R1Pub, d2R1Sec.identifier: d2R1Pub},
+          {d1R1Sec.identifier: tamperedShare, d2R1Sec.identifier: d2R2Out[receiverId]!},
+          minSigners,
+          maxSigners,
+          [d1R1Sec.identifier, d2R1Sec.identifier, receiverId],
+        ),
+        throwsA(isA<InvalidSecretShareException>()),
+      );
+    });
+  });
+}
+
+void _verifySigningPair(
+  KeyPackage kp1,
+  KeyPackage kp2,
+  PublicKeyPackage pkp,
+  Uint8List message,
+  String label,
+) {
+  final n1 = newNonce(kp1.secretShare);
+  final n2 = newNonce(kp2.secretShare);
+
+  final commitments = {
+    kp1.identifier: n1.commitments,
+    kp2.identifier: n2.commitments,
+  };
+  final signingPackage = SigningPackage(commitments, message);
+
+  final s1 = sign(signingPackage, n1, kp1);
+  final s2 = sign(signingPackage, n2, kp2);
+
+  final signature = aggregate(
+    signingPackage,
+    {kp1.identifier: s1, kp2.identifier: s2},
+    pkp,
+  );
+  signature.verify(pkp.verifyingKey, message);
+}


### PR DESCRIPTION
The wallet no longer generates a secret polynomial during DKG. Only the hardware signer and co-signer server act as dealers, with the wallet receiving a valid signing share as a passive participant. This means the group key is derived solely from the HW signer and server secrets, while any 2-of-3 participants can still sign.

Key changes:
- Add receiverIdentifiers parameter to dkgPart2/dkgPart3 (Dart + Rust)
- Add dkgPart3Receive for passive receiver finalization (Dart + Rust)
- Update pico-signer and signer-server protocols for receiver_identifiers
- Rewrite client doDkg() so wallet uses dkgPart3Receive instead of generating its own secret; wallet's DKG secret share becomes its auth key
- Server re-keys policy under wallet's verifying share and stores userSigningIdentifier for correct identifier resolution during signing