### PR TITLE
feat: Add wallet share restore via re-DKG with persisted secrets

### DIFF
--- a/ap/lib/usb/usb_hardware_signer.dart
+++ b/ap/lib/usb/usb_hardware_signer.dart
@@ -63,6 +63,31 @@ class UsbHardwareSigner implements HardwareSignerInterface {
   }
 
   @override
+  Future<DkgInitResult> restoreInit(int maxSigners, int minSigners) async {
+    final resp = await _transport.sendCommand({
+      'cmd': 'restore_init',
+      'max_signers': maxSigners,
+      'min_signers': minSigners,
+    });
+
+    final r1PkgJson = resp['round1_package_json'] as Map<String, dynamic>;
+    final round1Package = Round1Package.fromJson(r1PkgJson);
+
+    final vkHex = resp['verifying_key_hex'] as String;
+    final verifyingKeyBytes = hex.decode(vkHex);
+
+    final idHex = resp['identifier_hex'] as String;
+    final idBytes = Uint8List.fromList(hex.decode(idHex));
+    final identifier = Identifier.deserialize(idBytes);
+
+    return DkgInitResult(
+      round1Package: round1Package,
+      verifyingKeyBytes: verifyingKeyBytes,
+      identifier: identifier,
+    );
+  }
+
+  @override
   Future<Map<Identifier, Round2Package>> dkgRound2(
     Map<Identifier, Round1Package> othersRound1, {
     List<Identifier> receiverIdentifiers = const [],

--- a/client/lib/client.dart
+++ b/client/lib/client.dart
@@ -336,6 +336,145 @@ class MpcClient {
     await _saveState();
   }
 
+  /// Restore: re-derive the wallet's signing share using the same DKG secrets
+  /// stored on the hardware signer and server. The group public key stays the
+  /// same so the Bitcoin address (and funds) are preserved.
+  Future<void> doRestore() async {
+    await _store.init();
+    final signer = _hardwareSigner;
+
+    // 1. Hardware signer reuses stored DKG secret (same VK, same identifier)
+    final restoreInit = await signer.restoreInit(_maxSigners, _minSigners);
+    final hwVerifyingKey = restoreInit.verifyingKeyBytes;
+    final hwIdentifier = restoreInit.identifier;
+
+    // 2. Derive wallet identifier (deterministic — same as original DKG)
+    final walletIdInput = Uint8List.fromList(
+      [...'wallet:'.codeUnits, ...hwVerifyingKey],
+    );
+    final walletIdentifier = threshold.Identifier.derive(walletIdInput);
+
+    // Use HW VK as temporary session key during restore
+    final tempUserId = Uint8List.fromList(hwVerifyingKey);
+
+    // 3. Send Round1 packages to server with is_restore flag
+    final hwR1Json = jsonEncode(restoreInit.round1Package.toJson());
+
+    final reqWallet = DKGStep1Request()
+      ..userId = tempUserId
+      ..identifier = walletIdentifier.serialize()
+      ..round1Package = '' // passive receiver
+      ..isRestore = true;
+
+    final reqHw = DKGStep1Request()
+      ..userId = tempUserId
+      ..identifier = hwIdentifier.serialize()
+      ..round1Package = hwR1Json
+      ..isRestore = true;
+
+    final step1Futures = await Future.wait(
+        [_stub.dKGStep1(reqWallet), _stub.dKGStep1(reqHw)]);
+    final step1Resp = step1Futures[0];
+
+    // 4. Trigger Step 2 on server (server computes round2)
+    await _stub.dKGStep2(DKGStep2Request()..userId = tempUserId);
+
+    // 5. Parse dealer R1 packages (for HW signer and wallet)
+    final dealerR1ForHw = <threshold.Identifier, threshold.Round1Package>{};
+    final dealerR1ForWallet = <threshold.Identifier, threshold.Round1Package>{};
+
+    step1Resp.round1Packages.forEach((k, v) {
+      if (v.isEmpty) return;
+      final id = threshold.Identifier(BigInt.parse(k, radix: 16));
+      final pkg = threshold.Round1Package.fromJson(jsonDecode(v));
+      if (id != hwIdentifier) dealerR1ForHw[id] = pkg;
+      dealerR1ForWallet[id] = pkg;
+    });
+
+    // 6. HW signer computes shares for server + wallet
+    final sharesFromHw = await signer.dkgRound2(
+      dealerR1ForHw,
+      receiverIdentifiers: [walletIdentifier],
+    );
+
+    // 7. Send Round2 packages to server
+    final reqStep3Hw = DKGStep3Request()
+      ..userId = tempUserId
+      ..identifier = threshold.bigIntToBytes(hwIdentifier.toScalar())
+      ..round2PackagesForOthers.addAll(_buildSharesMap(sharesFromHw));
+
+    final reqStep3Wallet = DKGStep3Request()
+      ..userId = tempUserId
+      ..identifier = threshold.bigIntToBytes(walletIdentifier.toScalar());
+
+    final step3Futures = await Future.wait(
+        [_stub.dKGStep3(reqStep3Wallet), _stub.dKGStep3(reqStep3Hw)]);
+
+    // 8. Wallet receives shares from dealers (HW signer + server)
+    final sharesForWallet = _parseShares(step3Futures[0].round2PackagesForMe);
+    final sharesForHw = _parseShares(step3Futures[1].round2PackagesForMe);
+
+    // 9. Wallet finalizes as passive receiver
+    final allParticipantIds = <threshold.Identifier>[
+      ...dealerR1ForWallet.keys,
+      walletIdentifier,
+    ];
+    final (walletKeyPkg, pubKeyPkg) = threshold.dkgPart3Receive(
+      walletIdentifier,
+      dealerR1ForWallet,
+      sharesForWallet,
+      _minSigners,
+      _maxSigners,
+      allParticipantIds,
+    );
+
+    // 10. HW signer finalizes (stores updated key internally)
+    final dkgResult = await signer.dkgRound3(
+      dealerR1ForHw,
+      sharesForHw,
+      receiverIdentifiers: [walletIdentifier],
+    );
+
+    // 11. Wallet's new secret share becomes the auth key
+    _signingSecret = threshold.SecretKey(walletKeyPkg.secretShare);
+    _userId = threshold
+        .elemSerializeCompressed(walletKeyPkg.verifyingShare)
+        .toList();
+    _recoveryId = hwVerifyingKey.toList();
+
+    // 12. Store policies
+    _normalPolicy = SpendingPolicy(
+        id: "normal_policy_id",
+        keyPackage: walletKeyPkg,
+        publicKeyPackage: pubKeyPkg);
+
+    final recoveryVerifyingShare =
+        pubKeyPkg.verifyingShares[dkgResult.identifier];
+    if (recoveryVerifyingShare == null) {
+      throw StateError("Recovery identifier not found in public key package");
+    }
+
+    final recoveryKeyPkg = threshold.KeyPackage(
+      dkgResult.identifier,
+      BigInt.zero,
+      recoveryVerifyingShare,
+      pubKeyPkg.verifyingKey,
+      _minSigners,
+    );
+
+    _recoveryPolicy = RecoveryPolicy(
+        id: "recovery_policy_id",
+        keyPackage: recoveryKeyPkg,
+        publicKeyPackage: pubKeyPkg);
+
+    // Clear protected policies (verifying shares changed, old keys invalid)
+    _protectedPolicies.clear();
+
+    _authHelper = ClientAuthHelper.fromSigningSecret(_signingSecret!, _userId!);
+
+    await _saveState();
+  }
+
   // Note: PublicKey is the unifying key for all identities
   PublicKeyPackage? getTweakedPublicKeyPackage(List<int>? merkle_root) {
     final publicKeyPackage = _normalPolicy?.publicKeyPackage;

--- a/client/lib/hardware_signer.dart
+++ b/client/lib/hardware_signer.dart
@@ -58,6 +58,10 @@ abstract class HardwareSignerInterface {
   /// DKG round 1: generate secret on device, return Round1Package + identifier.
   Future<DkgInitResult> dkgInit(int maxSigners, int minSigners);
 
+  /// Restore round 1: reuse stored DKG secret, generate fresh coefficients.
+  /// Returns same verifying key/identifier as original DKG but different R1 package.
+  Future<DkgInitResult> restoreInit(int maxSigners, int minSigners);
+
   /// DKG round 2: verify others' Round1Packages, compute shares.
   /// [receiverIdentifiers] are passive participants who get shares but
   /// don't contribute a secret polynomial.
@@ -187,6 +191,31 @@ class TcpHardwareSigner implements HardwareSignerInterface {
   Future<DkgInitResult> dkgInit(int maxSigners, int minSigners) async {
     final resp = await _sendCommand({
       'cmd': 'dkg_init',
+      'max_signers': maxSigners,
+      'min_signers': minSigners,
+    });
+
+    final r1PkgJson = resp['round1_package_json'] as Map<String, dynamic>;
+    final round1Package = Round1Package.fromJson(r1PkgJson);
+
+    final vkHex = resp['verifying_key_hex'] as String;
+    final verifyingKeyBytes = hex.decode(vkHex);
+
+    final idHex = resp['identifier_hex'] as String;
+    final idBytes = Uint8List.fromList(hex.decode(idHex));
+    final identifier = Identifier.deserialize(idBytes);
+
+    return DkgInitResult(
+      round1Package: round1Package,
+      verifyingKeyBytes: verifyingKeyBytes,
+      identifier: identifier,
+    );
+  }
+
+  @override
+  Future<DkgInitResult> restoreInit(int maxSigners, int minSigners) async {
+    final resp = await _sendCommand({
+      'cmd': 'restore_init',
       'max_signers': maxSigners,
       'min_signers': minSigners,
     });

--- a/pico-signer/src/handler.rs
+++ b/pico-signer/src/handler.rs
@@ -33,6 +33,7 @@ pub struct SignerState {
     key_package: Option<KeyPackage>,
     public_key_package: Option<PublicKeyPackage>,
     pending_nonce: Option<SigningNonce>,
+    dkg_secret: Option<[u8; 32]>,
 }
 
 impl SignerState {
@@ -44,13 +45,15 @@ impl SignerState {
             key_package: None,
             public_key_package: None,
             pending_nonce: None,
+            dkg_secret: None,
         }
     }
 
     /// Restore key material loaded from flash.
-    pub fn restore_keys(&mut self, kp: KeyPackage, pkp: PublicKeyPackage) {
+    pub fn restore_keys(&mut self, kp: KeyPackage, pkp: PublicKeyPackage, dkg_secret: Option<[u8; 32]>) {
         self.key_package = Some(kp);
         self.public_key_package = Some(pkp);
+        self.dkg_secret = dkg_secret;
     }
 
     pub fn key_package(&self) -> Option<&KeyPackage> {
@@ -61,13 +64,20 @@ impl SignerState {
         self.public_key_package.as_ref()
     }
 
-    /// Returns true if DKG round 3 just completed (keys are freshly set).
+    pub fn dkg_secret(&self) -> Option<&[u8; 32]> {
+        self.dkg_secret.as_ref()
+    }
+
     pub fn handle(&mut self, req: Request) -> Response {
         match req {
             Request::DkgInit {
                 max_signers,
                 min_signers,
             } => self.handle_dkg_init(max_signers, min_signers),
+            Request::RestoreInit {
+                max_signers,
+                min_signers,
+            } => self.handle_restore_init(max_signers, min_signers),
             Request::DkgRound2 { round1_packages, receiver_identifiers } => {
                 self.handle_dkg_round2(round1_packages, receiver_identifiers)
             }
@@ -94,6 +104,9 @@ impl SignerState {
             coefficients.push(random_scalar(&mut self.rng));
         }
 
+        // Store the DKG secret for potential future restore
+        self.dkg_secret = Some(scalar_to_bytes(&secret));
+
         match dkg::dkg_part1(max_signers, min_signers, &secret, &coefficients, &mut self.rng) {
             Ok((secret_pkg, pub_pkg)) => {
                 let id_hex = hex_encode(&secret_pkg.identifier.serialize());
@@ -110,6 +123,48 @@ impl SignerState {
             }
             Err(e) => Response::Error {
                 error: format!("dkg_init failed: {}", e),
+            },
+        }
+    }
+
+    fn handle_restore_init(&mut self, max_signers: usize, min_signers: usize) -> Response {
+        let secret_bytes = match &self.dkg_secret {
+            Some(s) => *s,
+            None => {
+                return Response::Error {
+                    error: "no DKG secret stored; cannot restore (run initial DKG first)".into(),
+                }
+            }
+        };
+
+        // Reconstruct the same secret scalar from stored bytes
+        let secret = match scalar_from_bytes(&secret_bytes) {
+            Ok(s) => s,
+            Err(e) => return Response::Error { error: e },
+        };
+
+        // Generate fresh random coefficients (different polynomial, same constant term)
+        let mut coefficients = Vec::with_capacity(min_signers - 1);
+        for _ in 0..(min_signers - 1) {
+            coefficients.push(random_scalar(&mut self.rng));
+        }
+
+        match dkg::dkg_part1(max_signers, min_signers, &secret, &coefficients, &mut self.rng) {
+            Ok((secret_pkg, pub_pkg)) => {
+                let id_hex = hex_encode(&secret_pkg.identifier.serialize());
+                let vk_hex = hex_encode(&pub_pkg.verifying_key.serialize());
+                let r1_json = pub_pkg.to_json_value();
+
+                self.r1_secret = Some(secret_pkg);
+
+                Response::DkgInit {
+                    round1_package_json: r1_json,
+                    verifying_key_hex: vk_hex,
+                    identifier_hex: id_hex,
+                }
+            }
+            Err(e) => Response::Error {
+                error: format!("restore_init failed: {}", e),
             },
         }
     }
@@ -401,6 +456,17 @@ impl SignerState {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+fn scalar_from_bytes(bytes: &[u8; 32]) -> Result<Scalar, String> {
+    use k256::elliptic_curve::scalar::FromUintUnchecked;
+    use k256::U256;
+    let uint = U256::from_be_slice(bytes);
+    let s = Scalar::from_uint_unchecked(uint);
+    if bool::from(s.is_zero()) {
+        return Err("stored DKG secret is zero".into());
+    }
+    Ok(s)
+}
 
 fn random_scalar(rng: &mut impl rand_core::RngCore) -> Scalar {
     use k256::elliptic_curve::ops::Reduce;

--- a/pico-signer/src/main.rs
+++ b/pico-signer/src/main.rs
@@ -46,9 +46,9 @@ async fn main(_spawner: Spawner) {
 
     // 5. Initialize signer state
     let mut signer_state = handler::SignerState::new(pico_rng);
-    if let Some((kp, pkp)) = loaded_keys {
+    if let Some((kp, pkp, dkg_secret)) = loaded_keys {
         info!("Restored key material from flash");
-        signer_state.restore_keys(kp, pkp);
+        signer_state.restore_keys(kp, pkp, dkg_secret);
     } else {
         info!("No key material in flash -- awaiting DKG");
     }
@@ -173,7 +173,7 @@ fn process_message(
             // Persist keys after successful DKG round 3
             if is_dkg_round3 {
                 if let (Some(kp), Some(pkp)) = (state.key_package(), state.public_key_package()) {
-                    if let Err(()) = storage.save(kp, pkp) {
+                    if let Err(()) = storage.save(kp, pkp, state.dkg_secret()) {
                         warn!("Failed to persist key material to flash");
                     }
                 }

--- a/pico-signer/src/protocol.rs
+++ b/pico-signer/src/protocol.rs
@@ -21,6 +21,12 @@ pub enum Request {
         min_signers: usize,
     },
 
+    #[serde(rename = "restore_init")]
+    RestoreInit {
+        max_signers: usize,
+        min_signers: usize,
+    },
+
     #[serde(rename = "dkg_round2")]
     DkgRound2 {
         round1_packages: BTreeMap<String, serde_json::Value>,

--- a/pico-signer/src/storage.rs
+++ b/pico-signer/src/storage.rs
@@ -1,9 +1,16 @@
 //! Flash persistence for key material.
 //!
-//! Stores KeyPackage and PublicKeyPackage in the last 4KB flash sector
-//! so they survive power cycles.
+//! Stores KeyPackage, PublicKeyPackage, and (optionally) the original DKG
+//! secret in the last 4KB flash sector so they survive power cycles.
 //!
-//! Layout:
+//! Layout v2:
+//!   [magic:1=0xA5][version:1=0x02]
+//!   [secret_len:2 BE][DKG secret bytes (32)]
+//!   [kp_len:2 BE][KeyPackage JSON bytes]
+//!   [pkp_len:2 BE][PublicKeyPackage JSON bytes]
+//!   [crc32:4 BE] (over all preceding bytes)
+//!
+//! Layout v1 (backward-compatible read):
 //!   [magic:1=0xA5][version:1=0x01]
 //!   [kp_len:2 BE][KeyPackage JSON bytes]
 //!   [pkp_len:2 BE][PublicKeyPackage JSON bytes]
@@ -18,7 +25,8 @@ use threshold::keys::{KeyPackage, PublicKeyPackage};
 const STORAGE_OFFSET: u32 = 0x3FF000; // Last 4KB sector
 const SECTOR_SIZE: usize = ERASE_SIZE;
 const MAGIC: u8 = 0xA5;
-const VERSION: u8 = 0x01;
+const VERSION: u8 = 0x02;
+const VERSION_V1: u8 = 0x01;
 
 pub struct KeyStorage {
     flash: Flash<'static, embassy_rp::peripherals::FLASH, Async, { 4 * 1024 * 1024 }>,
@@ -35,18 +43,30 @@ impl KeyStorage {
     }
 
     /// Load key material from flash. Returns None if no valid data found.
-    pub fn load(&mut self) -> Option<(KeyPackage, PublicKeyPackage)> {
+    /// The optional `[u8; 32]` is the DKG secret (present in v2, absent in v1).
+    pub fn load(&mut self) -> Option<(KeyPackage, PublicKeyPackage, Option<[u8; 32]>)> {
         let mut buf = [0u8; SECTOR_SIZE];
         if self.flash.blocking_read(STORAGE_OFFSET, &mut buf).is_err() {
             warn!("Flash read failed");
             return None;
         }
 
-        if buf[0] != MAGIC || buf[1] != VERSION {
-            info!("No key material in flash (magic/version mismatch)");
+        if buf[0] != MAGIC {
+            info!("No key material in flash (magic mismatch)");
             return None;
         }
 
+        match buf[1] {
+            VERSION => self.load_v2(&buf),
+            VERSION_V1 => self.load_v1(&buf),
+            _ => {
+                info!("No key material in flash (version mismatch)");
+                None
+            }
+        }
+    }
+
+    fn load_v1(&self, buf: &[u8; SECTOR_SIZE]) -> Option<(KeyPackage, PublicKeyPackage, Option<[u8; 32]>)> {
         // Parse KeyPackage
         let kp_len = u16::from_be_bytes([buf[2], buf[3]]) as usize;
         if 4 + kp_len + 2 > SECTOR_SIZE - 4 {
@@ -82,20 +102,84 @@ impl KeyStorage {
         let kp = KeyPackage::from_json(kp_json).ok()?;
         let pkp = PublicKeyPackage::from_json(pkp_json).ok()?;
 
-        info!("Loaded key material from flash");
-        Some((kp, pkp))
+        info!("Loaded key material from flash (v1, no DKG secret)");
+        Some((kp, pkp, None))
+    }
+
+    fn load_v2(&self, buf: &[u8; SECTOR_SIZE]) -> Option<(KeyPackage, PublicKeyPackage, Option<[u8; 32]>)> {
+        // Parse DKG secret
+        let secret_len = u16::from_be_bytes([buf[2], buf[3]]) as usize;
+        if secret_len != 32 {
+            warn!("Invalid secret_len in flash: {}", secret_len);
+            return None;
+        }
+        let mut dkg_secret = [0u8; 32];
+        dkg_secret.copy_from_slice(&buf[4..36]);
+
+        // Parse KeyPackage
+        let kp_offset = 36;
+        let kp_len = u16::from_be_bytes([buf[kp_offset], buf[kp_offset + 1]]) as usize;
+        let kp_start = kp_offset + 2;
+        if kp_start + kp_len + 2 > SECTOR_SIZE - 4 {
+            warn!("Invalid kp_len in flash");
+            return None;
+        }
+        let kp_json = core::str::from_utf8(&buf[kp_start..kp_start + kp_len]).ok()?;
+
+        // Parse PublicKeyPackage
+        let pkp_offset = kp_start + kp_len;
+        let pkp_len = u16::from_be_bytes([buf[pkp_offset], buf[pkp_offset + 1]]) as usize;
+        let pkp_start = pkp_offset + 2;
+        if pkp_start + pkp_len > SECTOR_SIZE - 4 {
+            warn!("Invalid pkp_len in flash");
+            return None;
+        }
+        let pkp_json = core::str::from_utf8(&buf[pkp_start..pkp_start + pkp_len]).ok()?;
+
+        // Verify CRC32
+        let crc_offset = pkp_start + pkp_len;
+        let stored_crc = u32::from_be_bytes([
+            buf[crc_offset],
+            buf[crc_offset + 1],
+            buf[crc_offset + 2],
+            buf[crc_offset + 3],
+        ]);
+        let computed_crc = crc32(&buf[..crc_offset]);
+        if stored_crc != computed_crc {
+            warn!("Flash CRC mismatch");
+            return None;
+        }
+
+        let kp = KeyPackage::from_json(kp_json).ok()?;
+        let pkp = PublicKeyPackage::from_json(pkp_json).ok()?;
+
+        info!("Loaded key material from flash (v2, with DKG secret)");
+        Some((kp, pkp, Some(dkg_secret)))
     }
 
     /// Save key material to flash. Erases the sector first.
-    pub fn save(&mut self, kp: &KeyPackage, pkp: &PublicKeyPackage) -> Result<(), ()> {
+    pub fn save(
+        &mut self,
+        kp: &KeyPackage,
+        pkp: &PublicKeyPackage,
+        dkg_secret: Option<&[u8; 32]>,
+    ) -> Result<(), ()> {
         let kp_json = kp.to_json();
         let pkp_json = pkp.to_json();
 
         let kp_bytes = kp_json.as_bytes();
         let pkp_bytes = pkp_json.as_bytes();
 
-        // Build buffer
-        let total = 2 + 2 + kp_bytes.len() + 2 + pkp_bytes.len() + 4; // header + kp + pkp + crc
+        let secret_bytes: &[u8; 32] = match dkg_secret {
+            Some(s) => s,
+            None => {
+                error!("DKG secret required for v2 save");
+                return Err(());
+            }
+        };
+
+        // Build buffer: header(2) + secret_len(2) + secret(32) + kp_len(2) + kp + pkp_len(2) + pkp + crc(4)
+        let total = 2 + 2 + 32 + 2 + kp_bytes.len() + 2 + pkp_bytes.len() + 4;
         if total > SECTOR_SIZE {
             error!("Key material too large for flash sector");
             return Err(());
@@ -104,10 +188,19 @@ impl KeyStorage {
         let mut buf = [0xFFu8; SECTOR_SIZE];
         buf[0] = MAGIC;
         buf[1] = VERSION;
-        buf[2..4].copy_from_slice(&(kp_bytes.len() as u16).to_be_bytes());
-        buf[4..4 + kp_bytes.len()].copy_from_slice(kp_bytes);
 
-        let pkp_offset = 4 + kp_bytes.len();
+        // DKG secret
+        buf[2..4].copy_from_slice(&32u16.to_be_bytes());
+        buf[4..36].copy_from_slice(secret_bytes);
+
+        // KeyPackage
+        let kp_offset = 36;
+        buf[kp_offset..kp_offset + 2].copy_from_slice(&(kp_bytes.len() as u16).to_be_bytes());
+        let kp_start = kp_offset + 2;
+        buf[kp_start..kp_start + kp_bytes.len()].copy_from_slice(kp_bytes);
+
+        // PublicKeyPackage
+        let pkp_offset = kp_start + kp_bytes.len();
         buf[pkp_offset..pkp_offset + 2].copy_from_slice(&(pkp_bytes.len() as u16).to_be_bytes());
         let pkp_start = pkp_offset + 2;
         buf[pkp_start..pkp_start + pkp_bytes.len()].copy_from_slice(pkp_bytes);

--- a/protocol/lib/src/generated/mpc_wallet.pb.dart
+++ b/protocol/lib/src/generated/mpc_wallet.pb.dart
@@ -15,6 +15,7 @@ class DKGStep1Request extends $pb.GeneratedMessage {
     ..a<$core.List<$core.int>>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'userId', $pb.PbFieldType.OY)
     ..a<$core.List<$core.int>>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'identifier', $pb.PbFieldType.OY)
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'round1Package')
+    ..aOB(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'isRestore')
     ..hasRequiredFields = false
   ;
 
@@ -23,6 +24,7 @@ class DKGStep1Request extends $pb.GeneratedMessage {
     $core.List<$core.int>? userId,
     $core.List<$core.int>? identifier,
     $core.String? round1Package,
+    $core.bool? isRestore,
   }) {
     final _result = create();
     if (userId != null) {
@@ -33,6 +35,9 @@ class DKGStep1Request extends $pb.GeneratedMessage {
     }
     if (round1Package != null) {
       _result.round1Package = round1Package;
+    }
+    if (isRestore != null) {
+      _result.isRestore = isRestore;
     }
     return _result;
   }
@@ -83,6 +88,15 @@ class DKGStep1Request extends $pb.GeneratedMessage {
   $core.bool hasRound1Package() => $_has(2);
   @$pb.TagNumber(3)
   void clearRound1Package() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.bool get isRestore => $_getBF(3);
+  @$pb.TagNumber(4)
+  set isRestore($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasIsRestore() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearIsRestore() => clearField(4);
 }
 
 class DKGStep1Response extends $pb.GeneratedMessage {

--- a/protocol/lib/src/generated/mpc_wallet.pbjson.dart
+++ b/protocol/lib/src/generated/mpc_wallet.pbjson.dart
@@ -15,11 +15,12 @@ const DKGStep1Request$json = const {
     const {'1': 'user_id', '3': 1, '4': 1, '5': 12, '10': 'userId'},
     const {'1': 'identifier', '3': 2, '4': 1, '5': 12, '10': 'identifier'},
     const {'1': 'round1_package', '3': 3, '4': 1, '5': 9, '10': 'round1Package'},
+    const {'1': 'is_restore', '3': 4, '4': 1, '5': 8, '10': 'isRestore'},
   ],
 };
 
 /// Descriptor for `DKGStep1Request`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List dKGStep1RequestDescriptor = $convert.base64Decode('Cg9ES0dTdGVwMVJlcXVlc3QSFwoHdXNlcl9pZBgBIAEoDFIGdXNlcklkEh4KCmlkZW50aWZpZXIYAiABKAxSCmlkZW50aWZpZXISJQoOcm91bmQxX3BhY2thZ2UYAyABKAlSDXJvdW5kMVBhY2thZ2U=');
+final $typed_data.Uint8List dKGStep1RequestDescriptor = $convert.base64Decode('Cg9ES0dTdGVwMVJlcXVlc3QSFwoHdXNlcl9pZBgBIAEoDFIGdXNlcklkEh4KCmlkZW50aWZpZXIYAiABKAxSCmlkZW50aWZpZXISJQoOcm91bmQxX3BhY2thZ2UYAyABKAlSDXJvdW5kMVBhY2thZ2USHQoKaXNfcmVzdG9yZRgEIAEoCFIJaXNSZXN0b3Jl');
 @$core.Deprecated('Use dKGStep1ResponseDescriptor instead')
 const DKGStep1Response$json = const {
   '1': 'DKGStep1Response',

--- a/protos/mpc_wallet.proto
+++ b/protos/mpc_wallet.proto
@@ -36,8 +36,9 @@ service MPCWallet {
 
 message DKGStep1Request {
   bytes user_id = 1;
-  bytes identifier = 2;    
+  bytes identifier = 2;
   string round1_package = 3; // JSON
+  bool is_restore = 4; // If true, server reuses stored DKG secret instead of generating new one
 }
 
 message DKGStep1Response {

--- a/server/lib/persistence/store.dart
+++ b/server/lib/persistence/store.dart
@@ -109,6 +109,16 @@ class PolicyStore extends GenericStore {
   Future<void> savePolicy(String userId, String jsonData) =>
       save(userId, jsonData);
   Future<String?> getPolicy(String userId) => get(userId);
+
+  Future<Map<String, String>> getAllPolicies() async {
+    final keys = await getAllKeys();
+    final result = <String, String>{};
+    for (final key in keys) {
+      final value = await get(key);
+      if (value != null) result[key] = value;
+    }
+    return result;
+  }
 }
 
 class UtxoStore extends GenericStore {

--- a/server/lib/server.dart
+++ b/server/lib/server.dart
@@ -165,6 +165,29 @@ class MPCWalletService extends MPCWalletServiceBase {
     });
   }
 
+  /// Find an existing policy by its recoveryId (hex of HW signer's verifying key).
+  /// Used during restore to locate the stored server DKG secret.
+  Future<PolicyState?> _findPolicyByRecoveryId(String recoveryIdHex) async {
+    return await _policyLock.synchronized(() async {
+      // Check in-memory cache first
+      for (final policy in _policies.values) {
+        if (policy.recoveryId == recoveryIdHex) return policy;
+      }
+      // Try loading all policies from store
+      final allPolicies = await policyStore.getAllPolicies();
+      for (final entry in allPolicies.entries) {
+        try {
+          final ps = PolicyState.fromJson(jsonDecode(entry.value));
+          _policies[entry.key] = ps;
+          if (ps.recoveryId == recoveryIdHex) return ps;
+        } catch (e) {
+          _log.warning('Error loading policy ${entry.key}: $e');
+        }
+      }
+      return null;
+    });
+  }
+
   Future<UtxoState> _getUtxoState(String userId) async {
     return await _utxoLock.synchronized(() async {
       if (!_utxos.containsKey(userId)) {
@@ -221,6 +244,13 @@ class MPCWalletService extends MPCWalletServiceBase {
 
     final session = await _getDKGSession(userIdHex);
     try {
+      // Reset stale session state when starting a restore (or fresh DKG)
+      // to avoid reusing old round1 packages or server secrets.
+      if (request.isRestore && session.serverRound1SecretPackage != null) {
+        _log.info('[$userIdHex] DKGStep1: Resetting stale session for restore');
+        session.reset();
+      }
+
       final identifier = threshold.Identifier.deserialize(
           Uint8List.fromList(request.identifier));
 
@@ -237,8 +267,26 @@ class MPCWalletService extends MPCWalletServiceBase {
 
       // Server Init for this session
       if (session.serverRound1SecretPackage == null) {
-        _log.info('[$userIdHex] Server: Generating DKG secrets...');
-        final secret = threshold.SecretKey(threshold.modNRandom());
+        threshold.SecretKey secret;
+
+        if (request.isRestore) {
+          // Restore mode: reuse stored DKG secret from existing policy
+          _log.info('[$userIdHex] Server: Restore mode — looking up stored DKG secret...');
+          final existingPolicy = await _findPolicyByRecoveryId(userIdHex);
+          if (existingPolicy == null) {
+            throw StateError('No existing policy found for recovery ID $userIdHex');
+          }
+          if (existingPolicy.serverDkgSecretHex == null) {
+            throw StateError('Existing policy has no stored DKG secret (created before restore support)');
+          }
+          final secretBytes = hex.decode(existingPolicy.serverDkgSecretHex!);
+          secret = threshold.SecretKey(threshold.bytesToBigInt(Uint8List.fromList(secretBytes)));
+          _log.info('[$userIdHex] Server: Restored DKG secret from policy');
+        } else {
+          _log.info('[$userIdHex] Server: Generating DKG secrets...');
+          secret = threshold.SecretKey(threshold.modNRandom());
+        }
+
         final coeffs = threshold.generateCoefficients(thresholdCount - 1);
         final (r1Secret, r1Public) = threshold.dkgPart1(
             totalParticipants, thresholdCount, secret, coeffs);
@@ -431,11 +479,29 @@ class MPCWalletService extends MPCWalletServiceBase {
           policyUserId = userIdHex;
         }
 
-        // fresh policy state
+        // Persist the server's DKG secret scalar for future restore
+        final serverDkgSecretHex = hex.encode(
+            threshold.bigIntToBytes(session.serverInternalSecret!.scalar));
+
         final userRecoveryIdHex = hex.encode(userRecoveryIdentifier!);
+
+        // Check if this is a restore — look for existing policy with same recoveryId
+        final existingPolicy = await _findPolicyByRecoveryId(userRecoveryIdHex);
+        List<SpendingEntry> preservedHistory = [];
+        if (existingPolicy != null) {
+          preservedHistory = List.from(existingPolicy.spendingHistory);
+          // Remove old policy entry (userId may have changed)
+          _policies.remove(existingPolicy.userId);
+          await policyStore.delete(existingPolicy.userId);
+          _log.info('[$userIdHex] Restore: removed old policy under ${existingPolicy.userId}');
+        }
+
+        // Create fresh policy state
         final policyState = await _newPolicyState(
             policyUserId, userRecoveryIdHex, normalPolicy,
             userSigningIdentifier: walletSigningIdentifier);
+        policyState.serverDkgSecretHex = serverDkgSecretHex;
+        policyState.spendingHistory.addAll(preservedHistory);
         _policies[policyUserId] = policyState;
 
         _log.info('[$userId] DKG Complete. PK: ${pubKeyPkg.verifyingKey.E}');

--- a/server/lib/state.dart
+++ b/server/lib/state.dart
@@ -90,6 +90,11 @@ class PolicyState {
   // when the wallet is a passive receiver in DKG).
   threshold.Identifier? userSigningIdentifier;
 
+  // The server's original DKG secret (hex-encoded 32-byte scalar).
+  // Persisted so the server can re-derive the same polynomial constant term
+  // during a wallet restore flow.
+  String? serverDkgSecretHex;
+
   // normal Policy
   final NormalPolicy normalPolicy;
   // protected Policies
@@ -98,7 +103,7 @@ class PolicyState {
   final spendingHistory = <SpendingEntry>[];
 
   PolicyState(this.userId, this.recoveryId, this.normalPolicy,
-      {this.userSigningIdentifier});
+      {this.userSigningIdentifier, this.serverDkgSecretHex});
 
   Map<String, dynamic> toJson() {
     return {
@@ -107,6 +112,8 @@ class PolicyState {
       if (userSigningIdentifier != null)
         'userSigningIdentifier':
             hex.encode(userSigningIdentifier!.serialize()),
+      if (serverDkgSecretHex != null)
+        'serverDkgSecretHex': serverDkgSecretHex,
       'normalPolicy': normalPolicy.toJson(),
       'protectedPolicies':
           protectedPolicies.map((k, v) => MapEntry(k, v.toJson())),
@@ -122,7 +129,8 @@ class PolicyState {
     }
     final s = PolicyState(json['userId'], json['recoveryId'],
         NormalPolicy.fromJson(json['normalPolicy']),
-        userSigningIdentifier: signingId);
+        userSigningIdentifier: signingId,
+        serverDkgSecretHex: json['serverDkgSecretHex'] as String?);
 
     if (json['protectedPolicies'] != null) {
       final Map<String, dynamic> map = json['protectedPolicies'];

--- a/signer-server/src/handler.rs
+++ b/signer-server/src/handler.rs
@@ -21,6 +21,7 @@ pub struct SignerState {
     key_package: Option<KeyPackage>,
     public_key_package: Option<PublicKeyPackage>,
     pending_nonce: Option<SigningNonce>,
+    dkg_secret: Option<[u8; 32]>,
 }
 
 impl SignerState {
@@ -31,6 +32,7 @@ impl SignerState {
             key_package: None,
             public_key_package: None,
             pending_nonce: None,
+            dkg_secret: None,
         }
     }
 
@@ -40,6 +42,10 @@ impl SignerState {
                 max_signers,
                 min_signers,
             } => self.handle_dkg_init(max_signers, min_signers),
+            Request::RestoreInit {
+                max_signers,
+                min_signers,
+            } => self.handle_restore_init(max_signers, min_signers),
             Request::DkgRound2 { round1_packages, receiver_identifiers } => {
                 self.handle_dkg_round2(round1_packages, receiver_identifiers)
             }
@@ -69,6 +75,9 @@ impl SignerState {
             coefficients.push(random_scalar(&mut rng));
         }
 
+        // Store the DKG secret for potential future restore
+        self.dkg_secret = Some(scalar_to_bytes(&secret));
+
         match dkg::dkg_part1(max_signers, min_signers, &secret, &coefficients, &mut rng) {
             Ok((secret_pkg, pub_pkg)) => {
                 let id_hex = hex_encode(&secret_pkg.identifier.serialize());
@@ -85,6 +94,50 @@ impl SignerState {
             }
             Err(e) => Response::Error {
                 error: format!("dkg_init failed: {}", e),
+            },
+        }
+    }
+
+    fn handle_restore_init(&mut self, max_signers: usize, min_signers: usize) -> Response {
+        let secret_bytes = match &self.dkg_secret {
+            Some(s) => *s,
+            None => {
+                return Response::Error {
+                    error: "no DKG secret stored; cannot restore (run initial DKG first)".into(),
+                }
+            }
+        };
+
+        // Reconstruct the same secret scalar from stored bytes
+        let secret = match scalar_from_bytes(&secret_bytes) {
+            Ok(s) => s,
+            Err(e) => return Response::Error { error: e },
+        };
+
+        let mut rng = OsRng;
+
+        // Generate fresh random coefficients (different polynomial, same constant term)
+        let mut coefficients = Vec::with_capacity(min_signers - 1);
+        for _ in 0..(min_signers - 1) {
+            coefficients.push(random_scalar(&mut rng));
+        }
+
+        match dkg::dkg_part1(max_signers, min_signers, &secret, &coefficients, &mut rng) {
+            Ok((secret_pkg, pub_pkg)) => {
+                let id_hex = hex_encode(&secret_pkg.identifier.serialize());
+                let vk_hex = hex_encode(&pub_pkg.verifying_key.serialize());
+                let r1_json = pub_pkg.to_json_value();
+
+                self.r1_secret = Some(secret_pkg);
+
+                Response::DkgInit {
+                    round1_package_json: r1_json,
+                    verifying_key_hex: vk_hex,
+                    identifier_hex: id_hex,
+                }
+            }
+            Err(e) => Response::Error {
+                error: format!("restore_init failed: {}", e),
             },
         }
     }
@@ -386,6 +439,17 @@ impl SignerState {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+fn scalar_from_bytes(bytes: &[u8; 32]) -> Result<Scalar, String> {
+    use k256::elliptic_curve::scalar::FromUintUnchecked;
+    use k256::U256;
+    let uint = U256::from_be_slice(bytes);
+    let s = Scalar::from_uint_unchecked(uint);
+    if bool::from(s.is_zero()) {
+        return Err("stored DKG secret is zero".into());
+    }
+    Ok(s)
+}
 
 fn random_scalar(rng: &mut impl rand::RngCore) -> Scalar {
     use k256::elliptic_curve::ops::Reduce;

--- a/signer-server/src/protocol.rs
+++ b/signer-server/src/protocol.rs
@@ -14,6 +14,12 @@ pub enum Request {
         min_signers: usize,
     },
 
+    #[serde(rename = "restore_init")]
+    RestoreInit {
+        max_signers: usize,
+        min_signers: usize,
+    },
+
     #[serde(rename = "dkg_round2")]
     DkgRound2 {
         /// Keyed by identifier hex, value is Round1Package JSON


### PR DESCRIPTION
When wallet data is lost, the user can restore their signing share by re-running DKG with the same secrets stored on the hardware signer and server. This preserves the group public key (same Bitcoin address) while generating new per-participant shares.

- Extend Pico flash layout (v1→v2) to persist DKG secret scalar
- Add restore_init command to pico-signer and signer-server
- Add is_restore flag to DKGStep1Request proto message
- Server looks up existing policy by recoveryId during restore, reuses stored secret, and re-keys policy under new userId
- Add doRestore() to client, mirroring doDkg() with restore flags
- Reset stale DKG sessions on restore to prevent state conflicts