### PR TITLE
feat(contract): per-party contract cosigner group (1 cosigner, 1 user)

### DIFF
--- a/cosigner-runtime/src/contract/group.rs
+++ b/cosigner-runtime/src/contract/group.rs
@@ -1,0 +1,327 @@
+//! Contract cosigner GROUP — the per-contract binding that enforces the
+//! one-cosigner-one-user invariant for multi-user eVTXO contracts.
+//!
+//! Previously a single shared cosigner actor (keyed by the cooperative key `V′`)
+//! held EVERY recipient's counter-share `C_i` plus an N-entry authorization
+//! roster, so N parties wrote into one storage namespace. That defeats per-user
+//! enclave rollback detection: a user cannot keep a coherent post-write checksum
+//! chain when other parties interleave writes into the same actor's state.
+//!
+//! Now each party gets its OWN dedicated contract cosigner, keyed by a per-party
+//! id `cc_id = sha256(DOMAIN || V′ || recipient_vk)`, holding ONLY that party's
+//! `C_i` (a single-recipient policy) behind a single-entry roster — so the global
+//! invariant holds for contracts too: 1 cosigner ⇔ 1 id (its group key) ⇔ 1 user,
+//! each with its own isolated write stream.
+//!
+//! A `ContractCosignerGroup` (keyed by `V′`) binds the members together and
+//! carries the cross-party onboarding context — the cosigner's canonical `V′`
+//! key package and the eVTXO taptree params — which cannot belong to any single
+//! party. Clients still address the group by `V′`; the host fans a cooperative
+//! spend out to the spending party's `cc_id` (see `rest_api` sign routing).
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use tonic::Status;
+
+use crate::contract::crypto_host;
+use crate::persistence::KvStore;
+use crate::policy::{EvtxoPolicy, NormalPolicy, PolicyState, RecipientCosignerShare};
+
+/// Persistence tree: group id (`V′` compressed-pubkey hex) -> group JSON.
+pub const CONTRACT_GROUPS_TREE: &str = "contract_groups";
+
+/// Persistence tree mapping a cosigner id -> JSON array of authorized verifying
+/// shares. Mirrors `helpers::GROUP_AUTH_TREE`; duplicated here to avoid a
+/// handlers→contract dependency cycle.
+const GROUP_AUTH_TREE: &str = "group_auth_idx";
+
+/// Domain separator for the per-party cosigner id derivation.
+const CC_ID_DOMAIN: &[u8] = b"merlin:contract-cosigner-group:v1";
+
+/// One member of a contract cosigner group: a party's verifying share and the
+/// dedicated per-party cosigner id (its group key) that holds its `C_i`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractMember {
+    /// The party's main verifying share (hex) — the identity it authenticates as.
+    pub recipient_vk_hex: String,
+    /// The dedicated per-party contract cosigner id (hex) = `cc_id`.
+    pub cc_id_hex: String,
+}
+
+/// The per-contract binding over the per-party cosigners. Persisted under
+/// `contract_groups/<V′>`; replaces the single shared `is_contract` `V′` policy
+/// as the home for cross-party onboarding state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractCosignerGroup {
+    /// Group id = cooperative key `V′` (compressed verifying-key hex). Clients
+    /// address the group by this; the host fans spends out to a member `cc_id`.
+    pub group_id_hex: String,
+    /// The eVTXO scriptPubKey (hex) this group governs.
+    pub spk_hex: String,
+    /// Contract that gates cooperative spends: hex of sha256(component_wasm).
+    pub contract_id_hex: String,
+    /// `V′` x-only key (the cooperative-leaf key; same for every member).
+    pub evtxo_pk_xonly_hex: String,
+    /// The exit-leaf owner key (author's `V`, x-only hex) — members need it to
+    /// rebuild the taptree when spending the cooperative leaf.
+    pub owner_pk_xonly_hex: String,
+    /// The eVTXO's unilateral-exit CSV delay.
+    pub exit_delay: u32,
+    /// The cosigner's canonical `V′` key package (its master share for `V′`),
+    /// used to refresh per-party counter-shares during onboarding. Cross-party —
+    /// lives on the group, never on a member.
+    pub cosigner_vprime_kp_json: String,
+    /// The author's (recipient[0]'s) `V′` identifier hex — the second original
+    /// shareholder of `V′`, needed for the onboarding Lagrange coefficient.
+    pub author_id_hex: String,
+    /// The group roster: one dedicated cosigner per party.
+    pub members: Vec<ContractMember>,
+}
+
+impl ContractCosignerGroup {
+    /// The dedicated cosigner id for `recipient_vk_hex`, if it is a member.
+    pub fn member_cc_id(&self, recipient_vk_hex: &str) -> Option<String> {
+        self.members
+            .iter()
+            .find(|m| m.recipient_vk_hex == recipient_vk_hex)
+            .map(|m| m.cc_id_hex.clone())
+    }
+
+    /// Insert or replace a member (idempotent re-onboard).
+    pub fn upsert_member(&mut self, recipient_vk_hex: &str, cc_id_hex: &str) {
+        if let Some(m) = self
+            .members
+            .iter_mut()
+            .find(|m| m.recipient_vk_hex == recipient_vk_hex)
+        {
+            m.cc_id_hex = cc_id_hex.to_string();
+        } else {
+            self.members.push(ContractMember {
+                recipient_vk_hex: recipient_vk_hex.to_string(),
+                cc_id_hex: cc_id_hex.to_string(),
+            });
+        }
+    }
+}
+
+/// Derive the dedicated per-party cosigner id (hex) for `(group_id, recipient_vk)`.
+/// Deterministic and collision-resistant: `sha256(DOMAIN || V′ || recipient_vk)`.
+/// `group_id_hex` is the compressed `V′` hex; `recipient_vk_hex` the party's
+/// verifying share hex. Distinct per (contract, party) and stable across calls.
+pub fn derive_cc_id(group_id_hex: &str, recipient_vk_hex: &str) -> Result<String, Status> {
+    let group = hex::decode(group_id_hex)
+        .map_err(|e| Status::internal(format!("bad group_id hex: {e}")))?;
+    let vk = hex::decode(recipient_vk_hex)
+        .map_err(|e| Status::internal(format!("bad recipient_vk hex: {e}")))?;
+    let mut preimage = Vec::with_capacity(CC_ID_DOMAIN.len() + group.len() + vk.len());
+    preimage.extend_from_slice(CC_ID_DOMAIN);
+    preimage.extend_from_slice(&group);
+    preimage.extend_from_slice(&vk);
+    Ok(hex::encode(crypto_host::sha256(&preimage)))
+}
+
+/// Load a contract cosigner group by its id (`V′` hex). `None` on miss or a
+/// corrupt row (treated as "not a contract group").
+pub fn load(persistence: &dyn KvStore, group_id_hex: &str) -> Option<ContractCosignerGroup> {
+    match persistence.get(CONTRACT_GROUPS_TREE, group_id_hex) {
+        Ok(Some(json)) => serde_json::from_str(&json).ok(),
+        _ => None,
+    }
+}
+
+/// Persist a contract cosigner group under `contract_groups/<V′>`.
+pub fn save(persistence: &dyn KvStore, group: &ContractCosignerGroup) -> Result<(), Status> {
+    let json = serde_json::to_string(group)
+        .map_err(|e| Status::internal(format!("encode contract group: {e}")))?;
+    persistence
+        .put(CONTRACT_GROUPS_TREE, &group.group_id_hex, &json)
+        .map_err(|e| Status::internal(format!("persist contract group: {e}")))
+}
+
+/// Resolve the dispatch route for a cooperative spend: a party addressing the
+/// group by `V′` is fanned out to its dedicated cosigner `cc_id`. Returns `None`
+/// when `group_id_hex` is not a contract group (e.g. a one-shot `V′==V` eVTXO,
+/// or a normal wallet) or the signer is not a registered member — the caller
+/// then dispatches to the addressed route unchanged.
+pub fn spend_route(
+    persistence: &dyn KvStore,
+    group_id_hex: &str,
+    recipient_vk_hex: &str,
+) -> Option<String> {
+    load(persistence, group_id_hex)?.member_cc_id(recipient_vk_hex)
+}
+
+/// Register a party as a dedicated per-party contract cosigner and add it to the
+/// group. Mints `policies/<cc_id>` holding ONLY this party's counter-share
+/// (single-recipient `EvtxoPolicy`), a single-entry roster
+/// `group_auth_idx/<cc_id> = [recipient_vk]`, and a self-route
+/// `policy_owner_idx/<cc_id> = cc_id`. Pushes the member onto `group` (caller
+/// persists the group). Returns the new `cc_id`.
+///
+/// `c_kp_json` is the cosigner's `C_i` key package; `pkp_json` the 2-entry `V′`
+/// public key package `{recipient_id: P_i·G, cosigner_id: C_i·G}` for this party.
+pub fn register_member(
+    persistence: &dyn KvStore,
+    group: &mut ContractCosignerGroup,
+    recipient_vk_hex: &str,
+    c_kp_json: &str,
+    pkp_json: &str,
+) -> Result<String, Status> {
+    let cc_id = derive_cc_id(&group.group_id_hex, recipient_vk_hex)?;
+
+    // The dedicated cosigner holds exactly one recipient share for exactly one
+    // eVTXO. The cross-party onboarding fields stay empty here — they live on the
+    // group, not on a per-party member.
+    let mut recipient_shares = HashMap::new();
+    recipient_shares.insert(
+        recipient_vk_hex.to_string(),
+        RecipientCosignerShare {
+            key_package_json: c_kp_json.to_string(),
+            public_key_package_json: pkp_json.to_string(),
+        },
+    );
+    let mut evtxo_policies = HashMap::new();
+    evtxo_policies.insert(
+        group.spk_hex.clone(),
+        EvtxoPolicy {
+            contract_id_hex: group.contract_id_hex.clone(),
+            evtxo_pk_xonly_hex: group.evtxo_pk_xonly_hex.clone(),
+            recipient_shares,
+            cosigner_vprime_kp_json: String::new(),
+            author_id_hex: String::new(),
+            exit_delay: group.exit_delay,
+            owner_pk_xonly_hex: group.owner_pk_xonly_hex.clone(),
+        },
+    );
+
+    let policy = PolicyState {
+        cosigner_id: cc_id.clone(),
+        recovery_id: String::new(),
+        user_signing_identifier_hex: None,
+        server_dkg_secret_hex: None,
+        normal_policy: NormalPolicy {
+            id: String::new(),
+            key_package_json: String::new(),
+            public_key_package_json: String::new(),
+        },
+        evtxo_policies,
+        is_contract: true,
+    };
+    let policy_json = serde_json::to_string(&policy)
+        .map_err(|e| Status::internal(format!("encode member policy: {e}")))?;
+    persistence
+        .put("policies", &cc_id, &policy_json)
+        .map_err(|e| Status::internal(format!("persist member policy: {e}")))?;
+
+    // Single-entry roster: this cosigner authenticates exactly one user.
+    let roster = serde_json::to_string(&[recipient_vk_hex])
+        .map_err(|e| Status::internal(format!("encode member roster: {e}")))?;
+    persistence
+        .put(GROUP_AUTH_TREE, &cc_id, &roster)
+        .map_err(|e| Status::internal(format!("persist member roster: {e}")))?;
+
+    // Self-route so `/u/<cc_id>/` addressing resolves to this actor on respawn.
+    persistence
+        .put("policy_owner_idx", &cc_id, &cc_id)
+        .map_err(|e| Status::internal(format!("persist member policy_owner_idx: {e}")))?;
+
+    group.upsert_member(recipient_vk_hex, &cc_id);
+    Ok(cc_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persistence::PersistenceError;
+    use std::sync::Mutex as StdMutex;
+
+    #[derive(Default)]
+    struct MemStore(StdMutex<HashMap<String, String>>);
+    impl KvStore for MemStore {
+        fn get(&self, tree: &str, key: &str) -> Result<Option<String>, PersistenceError> {
+            Ok(self.0.lock().unwrap().get(&format!("{tree}/{key}")).cloned())
+        }
+        fn put(&self, tree: &str, key: &str, value: &str) -> Result<(), PersistenceError> {
+            self.0
+                .lock()
+                .unwrap()
+                .insert(format!("{tree}/{key}"), value.to_string());
+            Ok(())
+        }
+        fn delete(&self, tree: &str, key: &str) -> Result<(), PersistenceError> {
+            self.0.lock().unwrap().remove(&format!("{tree}/{key}"));
+            Ok(())
+        }
+        fn get_all(&self, _tree: &str) -> Result<HashMap<String, String>, PersistenceError> {
+            Ok(HashMap::new())
+        }
+        fn clear(&self, _tree: &str) -> Result<(), PersistenceError> {
+            Ok(())
+        }
+    }
+
+    fn sample_group() -> ContractCosignerGroup {
+        ContractCosignerGroup {
+            group_id_hex: "02".to_string() + &"ab".repeat(32),
+            spk_hex: "51".repeat(34),
+            contract_id_hex: "cc".repeat(32),
+            evtxo_pk_xonly_hex: "ab".repeat(32),
+            owner_pk_xonly_hex: "cd".repeat(32),
+            exit_delay: 144,
+            cosigner_vprime_kp_json: "{}".to_string(),
+            author_id_hex: "11".repeat(32),
+            members: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn cc_id_is_deterministic_and_per_party() {
+        let g = sample_group();
+        let alice = "02".to_string() + &"11".repeat(32);
+        let bob = "02".to_string() + &"22".repeat(32);
+        let a1 = derive_cc_id(&g.group_id_hex, &alice).unwrap();
+        let a2 = derive_cc_id(&g.group_id_hex, &alice).unwrap();
+        let b1 = derive_cc_id(&g.group_id_hex, &bob).unwrap();
+        assert_eq!(a1, a2, "derivation must be stable");
+        assert_ne!(a1, b1, "distinct parties get distinct cosigners");
+        assert_eq!(a1.len(), 64, "cc_id is a 32-byte hash hex");
+    }
+
+    #[test]
+    fn register_member_isolates_each_party() {
+        let store = MemStore::default();
+        let mut g = sample_group();
+        let alice = "02".to_string() + &"11".repeat(32);
+        let bob = "02".to_string() + &"22".repeat(32);
+
+        let cc_alice = register_member(&store, &mut g, &alice, "{\"kp\":\"a\"}", "{\"pkp\":\"a\"}").unwrap();
+        let cc_bob = register_member(&store, &mut g, &bob, "{\"kp\":\"b\"}", "{\"pkp\":\"b\"}").unwrap();
+        save(&store, &g).unwrap();
+
+        // Two members, two distinct dedicated cosigners.
+        assert_eq!(g.members.len(), 2);
+        assert_ne!(cc_alice, cc_bob);
+
+        // Each cosigner's policy holds ONLY its own recipient share.
+        let pa: PolicyState =
+            serde_json::from_str(&store.get("policies", &cc_alice).unwrap().unwrap()).unwrap();
+        assert!(pa.is_contract);
+        let ep = pa.evtxo_policies.get(&g.spk_hex).unwrap();
+        assert_eq!(ep.recipient_shares.len(), 1);
+        assert!(ep.recipient_shares.contains_key(&alice));
+        assert!(!ep.recipient_shares.contains_key(&bob));
+
+        // Each roster authenticates exactly one user.
+        let roster: Vec<String> =
+            serde_json::from_str(&store.get(GROUP_AUTH_TREE, &cc_alice).unwrap().unwrap()).unwrap();
+        assert_eq!(roster, vec![alice.clone()]);
+
+        // Self-route + group fan-out resolve to the right cosigner.
+        assert_eq!(store.get("policy_owner_idx", &cc_alice).unwrap().unwrap(), cc_alice);
+        assert_eq!(spend_route(&store, &g.group_id_hex, &alice).unwrap(), cc_alice);
+        assert_eq!(spend_route(&store, &g.group_id_hex, &bob).unwrap(), cc_bob);
+        // A non-member does not resolve to any cosigner.
+        assert!(spend_route(&store, &g.group_id_hex, &("02".to_string() + &"33".repeat(32))).is_none());
+    }
+}

--- a/cosigner-runtime/src/contract/mod.rs
+++ b/cosigner-runtime/src/contract/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod crypto_host;
 mod engine;
+pub mod group;
 mod registry;
 
 pub use engine::{

--- a/cosigner-runtime/src/cosigner/handlers/onboard.rs
+++ b/cosigner-runtime/src/cosigner/handlers/onboard.rs
@@ -27,16 +27,13 @@ use threshold::scalar::{scalar_from_bytes, scalar_to_bytes};
 use crate::auth::message::{OP_EVTXO_ACK, OP_EVTXO_ONBOARD, OP_EVTXO_PENDING};
 use crate::cosigner::registry::CosignerInstance;
 use crate::cosigner::state::CosignerState;
-use crate::policy::RecipientCosignerShare;
 use crate::shared::SharedServices;
 use crate::wallet_proto::{
     EvtxoAckShareRequest, EvtxoAckShareResponse, EvtxoOnboardRequest, EvtxoOnboardResponse,
     EvtxoPendingSharesRequest, EvtxoPendingSharesResponse, PendingContractShare,
 };
 
-use super::helpers::{
-    auth_check, auth_check_group, ensure_policy_loaded, load_group_auth, persist_group_auth,
-};
+use super::helpers::{auth_check, auth_check_group, ensure_policy_loaded, load_group_auth};
 use super::parsers;
 
 const PENDING_TREE: &str = "pending_contract_shares";
@@ -100,14 +97,17 @@ pub fn evtxo_onboard(
         shared.secret_store.as_ref(),
         &own_id,
     )?;
-    let mut policy = user
+    let is_contract = user
         .policy_state
-        .clone()
-        .ok_or_else(|| Status::not_found("no policy state"))?;
-    if !policy.is_contract {
+        .as_ref()
+        .ok_or_else(|| Status::not_found("no policy state"))?
+        .is_contract;
+    if !is_contract {
         return Err(Status::failed_precondition("not a contract actor"));
     }
-    let mut authorized = load_group_auth(shared.persistence.as_ref(), &own_id);
+    // Onboarding authenticates the AUTHOR (the only entry on the coordinator's
+    // roster) — the group owner who deals refresh halves for new participants.
+    let authorized = load_group_auth(shared.persistence.as_ref(), &own_id);
     auth_check_group(
         user,
         state,
@@ -118,23 +118,25 @@ pub fn evtxo_onboard(
         OP_EVTXO_ONBOARD,
     )?;
 
+    // The cross-party onboarding context lives on the contract GROUP record, not on
+    // any single party's policy.
+    let mut group = crate::contract::group::load(shared.persistence.as_ref(), &own_id)
+        .ok_or_else(|| Status::not_found("no contract group for this actor"))?;
     let spk_hex = hex::encode(&req.evtxo_script_pubkey);
-    let ep = policy
-        .evtxo_policies
-        .get(&spk_hex)
-        .ok_or_else(|| Status::not_found("no such eVTXO on this contract"))?
-        .clone();
-    if ep.cosigner_vprime_kp_json.is_empty() || ep.author_id_hex.is_empty() {
+    if spk_hex != group.spk_hex {
+        return Err(Status::not_found("no such eVTXO on this contract"));
+    }
+    if group.cosigner_vprime_kp_json.is_empty() || group.author_id_hex.is_empty() {
         return Err(Status::failed_precondition(
             "contract does not support onboarding (one-shot V′==V)",
         ));
     }
 
     // The cosigner's canonical V′ key package + the original shareholder id-set.
-    let holder_kp = KeyPackage::from_json(&ep.cosigner_vprime_kp_json)
+    let holder_kp = KeyPackage::from_json(&group.cosigner_vprime_kp_json)
         .map_err(|e| Status::internal(format!("bad cosigner V′ kp: {e}")))?;
     let cosigner_id = holder_kp.identifier.clone();
-    let author_id = parse_id(&ep.author_id_hex)?;
+    let author_id = parse_id(&group.author_id_hex)?;
     let id_set = [author_id, cosigner_id.clone()];
 
     // The participant's V′ identifier id_i = derive(recipient_vk) — must match what the
@@ -174,7 +176,7 @@ pub fn evtxo_onboard(
     // V′ verifying key (even-Y ⇒ compressed prefix 0x02 over the x-only key).
     let mut vprime_bytes = [0u8; 33];
     vprime_bytes[0] = 0x02;
-    let xonly = hex::decode(&ep.evtxo_pk_xonly_hex)
+    let xonly = hex::decode(&group.evtxo_pk_xonly_hex)
         .map_err(|e| Status::internal(format!("bad evtxo_pk_xonly: {e}")))?;
     if xonly.len() != 32 {
         return Err(Status::internal("evtxo_pk_xonly must be 32 bytes"));
@@ -201,32 +203,19 @@ pub fn evtxo_onboard(
     };
     let pkp_json = pkp.to_json();
 
-    // Register the participant on the contract policy (recipient_shares + group auth).
+    // Mint the participant's OWN dedicated contract cosigner `cc_id` (single
+    // recipient share, single-user roster) and add it to the group. No share is
+    // written into a shared actor — the participant gets an isolated cosigner, so
+    // 1 cosigner ⇔ 1 id ⇔ 1 user holds for it too.
     let recipient_vk_hex = hex::encode(&req.recipient_vk);
-    policy
-        .evtxo_policies
-        .get_mut(&spk_hex)
-        .ok_or_else(|| Status::internal("eVTXO vanished"))?
-        .recipient_shares
-        .insert(
-            recipient_vk_hex.clone(),
-            RecipientCosignerShare {
-                key_package_json: c_kp.to_json(),
-                public_key_package_json: pkp_json.clone(),
-            },
-        );
-    let policy_json = serde_json::to_string(&policy)
-        .map_err(|e| Status::internal(format!("encode contract policy: {e}")))?;
-    shared
-        .persistence
-        .put("policies", &own_id, &policy_json)
-        .map_err(|e| Status::internal(format!("persist contract policy: {e}")))?;
-    user.policy_state = Some(policy);
-
-    if !authorized.contains(&recipient_vk_hex) {
-        authorized.push(recipient_vk_hex.clone());
-        persist_group_auth(shared.persistence.as_ref(), &own_id, &authorized)?;
-    }
+    crate::contract::group::register_member(
+        shared.persistence.as_ref(),
+        &mut group,
+        &recipient_vk_hex,
+        &c_kp.to_json(),
+        &pkp_json,
+    )?;
+    crate::contract::group::save(shared.persistence.as_ref(), &group)?;
 
     // ECIES the cosigner's half b@id_i to the participant; hold both halves (the
     // author's + the cosigner's) in the participant's pickup inbox.
@@ -243,12 +232,12 @@ pub fn evtxo_onboard(
     pending.push(PendingShareRecord {
         spk_hex: spk_hex.clone(),
         contract_group_id_hex: own_id.clone(),
-        contract_id_hex: ep.contract_id_hex.clone(),
+        contract_id_hex: group.contract_id_hex.clone(),
         ecies_author_hex: hex::encode(&req.ecies_a_at_participant),
         ecies_cosigner_hex: hex::encode(ecies_cosigner),
         pkp_json,
-        exit_delay: ep.exit_delay,
-        owner_pk_xonly_hex: ep.owner_pk_xonly_hex.clone(),
+        exit_delay: group.exit_delay,
+        owner_pk_xonly_hex: group.owner_pk_xonly_hex.clone(),
     });
     save_pending(shared.persistence.as_ref(), &recipient_vk_hex, &pending)?;
 

--- a/cosigner-runtime/src/onboarding/evtxo.rs
+++ b/cosigner-runtime/src/onboarding/evtxo.rs
@@ -568,8 +568,9 @@ fn step3_finalize(sess: &mut DkgSession, shared: &SharedServices) -> Result<Vec<
     )?;
     let spk_hex = hex::encode(&spk);
 
-    // The contract's group id = V′ (compressed verifying-key hex) — the address of
-    // the contract cosigner actor. Captured before pkp_json is moved below.
+    // The contract's group id = V′ (compressed verifying-key hex) — the address
+    // clients use; the host fans cooperative spends out to each member's dedicated
+    // cosigner. Captured before pkp_json is moved below.
     let v_prime_group_id = parsers::extract_verifying_key(&pkp_json)?;
 
     // Onboarding inputs (captured before the JSONs move): the cosigner's canonical V′
@@ -578,44 +579,41 @@ fn step3_finalize(sess: &mut DkgSession, shared: &SharedServices) -> Result<Vec<
     let cosigner_vprime_kp_json = kp_json.clone();
     let author_id_hex = parsers::extract_recipient_identifier(&pkp_json, &cosigner_id_hex)?;
 
-    // Build the (single-recipient) EvtxoPolicy: the author keyed by its own user_id.
-    // The per-participant refresh (Phase 4) adds further recipients keyed by their
-    // own verifying share.
+    // Build the CONTRACT COSIGNER GROUP (keyed by V′). It owns the cross-party
+    // onboarding context — the cosigner's canonical V′ key package + the eVTXO
+    // taptree params — that cannot belong to any single party.
     let user_id_hex = sess.user_id_hex.clone();
-    let mut recipient_shares = HashMap::new();
-    recipient_shares.insert(
-        user_id_hex.clone(),
-        RecipientCosignerShare {
-            key_package_json: kp_json,
-            public_key_package_json: pkp_json,
-        },
-    );
-    let evtxo_policy = EvtxoPolicy {
+    let mut group = contract::group::ContractCosignerGroup {
+        group_id_hex: v_prime_group_id.clone(),
+        spk_hex: spk_hex.clone(),
         contract_id_hex: hex::encode(&contract_id),
         evtxo_pk_xonly_hex: evtxo_pk_xonly,
-        recipient_shares,
+        owner_pk_xonly_hex: owner_pk_xonly,
+        exit_delay: sess.reshare_exit_delay,
         cosigner_vprime_kp_json,
         author_id_hex,
-        exit_delay: sess.reshare_exit_delay,
-        owner_pk_xonly_hex: owner_pk_xonly,
+        members: Vec::new(),
     };
 
-    // (a) Author's own policy copy — lets the author spend the eVTXO via its own
-    // actor today (the single-author path).
-    let mut policy = load_policy(shared, &user_id_hex)?;
-    policy
-        .evtxo_policies
-        .insert(spk_hex.clone(), evtxo_policy.clone());
-    persist_policy(shared, &user_id_hex, &policy)?;
+    // Register the author as the FIRST member: its own dedicated contract cosigner
+    // `cc_id`, holding only the author's counter-share behind a single-user roster.
+    // The author spends via this cosigner (the host routes `/u/<V′>/` → `cc_id`);
+    // no shared multi-party actor is created.
+    contract::group::register_member(
+        shared.persistence.as_ref(),
+        &mut group,
+        &user_id_hex,
+        &kp_json,
+        &pkp_json,
+    )?;
+    contract::group::save(shared.persistence.as_ref(), &group)?;
 
-    // (b) Stand up the CONTRACT cosigner actor, addressable by GroupID = V′. It
-    // spawns lazily on the first `/u/<V′>/` request and rehydrates this policy. Its
-    // `normal_policy` is a placeholder (it has no normal 2-of-2 wallet); recipients
-    // authenticate with their own verifying share via `auth_check_group` against
-    // `group_auth_idx[V′]`.
-    let mut contract_evtxo_policies = HashMap::new();
-    contract_evtxo_policies.insert(spk_hex, evtxo_policy);
-    let contract_policy = PolicyState {
+    // Stand up the GROUP COORDINATOR actor, addressable by GroupID = V′. It owns
+    // onboarding only (it co-signs no spends) and authenticates ONLY the author —
+    // so it too respects 1 actor ⇔ 1 user. It spawns lazily on the first
+    // `/u/<V′>/evtxo/onboard` request; its `normal_policy` + `evtxo_policies` are
+    // empty placeholders (onboarding reads context from the group record).
+    let coordinator_policy = PolicyState {
         cosigner_id: v_prime_group_id.clone(),
         recovery_id: String::new(),
         user_signing_identifier_hex: None,
@@ -625,15 +623,15 @@ fn step3_finalize(sess: &mut DkgSession, shared: &SharedServices) -> Result<Vec<
             key_package_json: String::new(),
             public_key_package_json: String::new(),
         },
-        evtxo_policies: contract_evtxo_policies,
+        evtxo_policies: HashMap::new(),
         is_contract: true,
     };
-    let contract_json = serde_json::to_string(&contract_policy)
-        .map_err(|e| Status::internal(format!("serialize contract policy: {e}")))?;
+    let coordinator_json = serde_json::to_string(&coordinator_policy)
+        .map_err(|e| Status::internal(format!("serialize coordinator policy: {e}")))?;
     shared
         .persistence
-        .put("policies", &v_prime_group_id, &contract_json)
-        .map_err(|e| Status::internal(format!("persist contract policy: {e}")))?;
+        .put("policies", &v_prime_group_id, &coordinator_json)
+        .map_err(|e| Status::internal(format!("persist coordinator policy: {e}")))?;
     helpers::persist_group_auth(
         shared.persistence.as_ref(),
         &v_prime_group_id,
@@ -644,7 +642,9 @@ fn step3_finalize(sess: &mut DkgSession, shared: &SharedServices) -> Result<Vec<
         .put("policy_owner_idx", &v_prime_group_id, &v_prime_group_id)
         .map_err(|e| Status::internal(format!("persist policy_owner_idx: {e}")))?;
 
-    tracing::info!("[{user_id_hex}] EvtxoKeygen complete; contract actor V′={v_prime_group_id}");
+    tracing::info!(
+        "[{user_id_hex}] EvtxoKeygen complete; contract group V′={v_prime_group_id} (author is member 1)"
+    );
     Ok(spk)
 }
 

--- a/cosigner-runtime/src/rest_api.rs
+++ b/cosigner-runtime/src/rest_api.rs
@@ -361,6 +361,23 @@ async fn evtxo_keygen_step3(
 // Signing
 // ---------------------------------------------------------------------------
 
+/// Resolve the actor to dispatch a (possibly contract) spend to. A party
+/// addressing a contract cosigner GROUP by `V′` (URL route) with its own
+/// `claimed_share` is fanned out to its dedicated per-party cosigner `cc_id`, so
+/// the spend lands on an isolated single-user actor. All other routes — normal
+/// wallets, and one-shot `V′==V` eVTXOs that aren't groups — are unchanged.
+fn spend_dispatch_route(reg: &CosignerRegistry, route: &str, claimed_share: &[u8]) -> String {
+    if claimed_share.is_empty() {
+        return route.to_string();
+    }
+    crate::contract::group::spend_route(
+        reg.shared().persistence.as_ref(),
+        route,
+        &hex::encode(claimed_share),
+    )
+    .unwrap_or_else(|| route.to_string())
+}
+
 #[tracing::instrument(skip_all, name = "rest::sign_step1", fields(user_id = %user_id))]
 async fn sign_step1(
     State(reg): State<Arc<CosignerRegistry>>,
@@ -376,6 +393,7 @@ async fn sign_step1(
     } else {
         claimed_share.clone()
     };
+    let route = spend_dispatch_route(&reg, &user_id, &claimed_share);
     let req = wallet_proto::SignStep1Request {
         user_id: req_user_id,
         hiding_commitment: hex_field(&body, "hiding_commitment"),
@@ -388,7 +406,7 @@ async fn sign_step1(
         claimed_share,
     };
     match reg
-        .dispatch(&user_id, move |reply| CosignerCommand::SignStep1 { req, reply })
+        .dispatch(&route, move |reply| CosignerCommand::SignStep1 { req, reply })
         .await
     {
         Ok(r) => {
@@ -425,6 +443,7 @@ async fn sign_step2(
     } else {
         claimed_share.clone()
     };
+    let route = spend_dispatch_route(&reg, &user_id, &claimed_share);
     let req = wallet_proto::SignStep2Request {
         user_id: req_user_id,
         signature_share: hex_field(&body, "signature_share"),
@@ -433,7 +452,7 @@ async fn sign_step2(
         claimed_share,
     };
     match reg
-        .dispatch(&user_id, move |reply| CosignerCommand::SignStep2 { req, reply })
+        .dispatch(&route, move |reply| CosignerCommand::SignStep2 { req, reply })
         .await
     {
         Ok(r) => Ok(Json(json!({

--- a/protocol/protos/mpc_wallet.proto
+++ b/protocol/protos/mpc_wallet.proto
@@ -111,9 +111,11 @@ message SignStep1Request {
   bytes full_transaction = 6;
   int64 timestamp_ms = 7; // Unix timestamp in milliseconds for replay protection
   bool script_path_spend = 8; // If true, skip taproot tweak (script-path signing)
-  // For a contract eVTXO spend: user_id routes to the contract actor (GroupID=V′),
-  // and claimed_share is the spending recipient's own verifying share (the cosigner
-  // authenticates it via auth_check_group + selects recipient_shares[claimed_share]).
+  // For a contract eVTXO spend: the URL route is the contract cosigner GROUP (V′)
+  // and claimed_share is the spending recipient's own verifying share. The host
+  // fans this out to the recipient's DEDICATED per-party cosigner (cc_id =
+  // sha256(V′||recipient_vk)) — an isolated single-user actor that holds only this
+  // recipient's counter-share — preserving the 1-cosigner-1-user invariant.
   // Empty for a normal wallet (claimed share = user_id).
   bytes claimed_share = 9;
 }
@@ -505,14 +507,15 @@ message EvtxoKeygenStep3Response {
 }
 
 // Onboard one participant to a contract eVTXO. Routed to the contract actor
-// (user_id = V′); the author authenticates via auth_check_group. The author has
-// computed its key-preserving refresh half a_i = refresh_share_to_id(...) onto the
-// participant's identifier id_i = derive(recipient_vk); it sends a_i(cosigner_id) as
-// a scalar (so the cosigner can form C_i), a_i(id_i)·G as a point (so the cosigner can
+// (user_id = V′); the author (the group owner) authenticates via auth_check_group.
+// The author has computed its key-preserving refresh half a_i = refresh_share_to_id(...)
+// onto the participant's identifier id_i = derive(recipient_vk); it sends a_i(cosigner_id)
+// as a scalar (so the cosigner can form C_i), a_i(id_i)·G as a point (so the cosigner can
 // form the participant's verifying share P_i·G without learning a_i(id_i)), and
 // ECIES(a_i(id_i)) encrypted to the participant. The cosigner computes its own half
-// b_i, forms C_i + the 2-entry V′ PKP, registers the participant, and holds BOTH
-// ECIES halves in the participant's pickup inbox. Neither side learns P_i.
+// b_i, forms C_i + the 2-entry V′ PKP, MINTS the participant's own dedicated per-party
+// cosigner (cc_id) holding only C_i, adds it to the contract cosigner group, and holds
+// BOTH ECIES halves in the participant's pickup inbox. Neither side learns P_i.
 message EvtxoOnboardRequest {
   bytes user_id = 1;                  // the author (claimed share; routes via V′ path)
   bytes evtxo_script_pubkey = 2;      // the contract eVTXO this participant joins
@@ -522,7 +525,7 @@ message EvtxoOnboardRequest {
   bytes ecies_a_at_participant = 6;   // ECIES(a_i(id_i)) to recipient_vk
   bytes signature = 7;                // author auth (binds user_id)
   int64 timestamp_ms = 8;
-  bytes contract_group_id = 9;        // V′ — routes to the contract actor (REST URL)
+  bytes contract_group_id = 9;        // V′ — the contract cosigner group (REST URL route)
 }
 message EvtxoOnboardResponse {
   bool ok = 1;
@@ -539,7 +542,7 @@ message EvtxoPendingSharesResponse {
 }
 message PendingContractShare {
   bytes evtxo_script_pubkey = 1;
-  bytes contract_group_id = 2;          // V′ (the contract actor to address at spend)
+  bytes contract_group_id = 2;          // V′ (the contract cosigner group to address at spend)
   bytes contract_id = 3;                // sha256(wasm)
   bytes ecies_half_author = 4;          // ECIES(a_i(id_i))
   bytes ecies_half_cosigner = 5;        // ECIES(b_i(id_i))


### PR DESCRIPTION
## Problem

The multi-user contract path stood up a **single shared cosigner actor** keyed by the cooperative key `V′`. That one actor held **every** recipient's counter-share `C_i` in a single `recipient_shares` map behind an **N-entry** authorization roster (`group_auth_idx[V′]`), and every party resolved to it via `policy_owner_idx[V′] = V′`.

So N parties wrote into **one** actor's storage namespace. This violates the *one-cosigner-one-user* invariant the rest of the system holds (a normal wallet is `1 cosigner = 1 id = its group key = 1 user`), and it defeats per-user enclave **rollback detection**: a user can't keep a coherent post-write checksum chain when other parties interleave writes into the same actor's state.

## Fix — a contract cosigner *group*

Introduce a first-class **`ContractCosignerGroup`** (persisted under `contract_groups/<V′>`) that binds a group of **dedicated per-party cosigners** and carries the cross-party onboarding context — the cosigner's canonical `V′` key package and the eVTXO taptree params — which legitimately cannot belong to any single party.

Each party now gets its **own** dedicated contract cosigner, keyed by

```
cc_id = sha256("merlin:contract-cosigner-group:v1" || V′ || recipient_vk)
```

holding **only** that party's `C_i` (a single-recipient `EvtxoPolicy`) behind a **single-entry** roster — so the global invariant holds for contracts too: **1 cosigner ⇔ 1 id (its group key) ⇔ 1 user**, each with its own isolated write stream.

## Wire protocol is unchanged

Clients still address the group by `V′` and send their own `claimed_share`. The change is entirely server-side:

- The host **fans a cooperative spend out** to the spending party's `cc_id` (`rest_api` SignStep1/2 routing), so the spend lands on an isolated single-user actor.
- The addressed `V′` actor becomes a thin **group coordinator** that owns onboarding only and authenticates just the author (so it too is `1 actor ⇔ 1 user`).
- One-shot `V′ == V` single-author eVTXOs (already single-user, never a group) are untouched — `spend_route` returns `None` and the route is unchanged.

## Changes

| File | What |
|------|------|
| `contract/group.rs` *(new)* | `ContractCosignerGroup`, `cc_id` derivation, `register_member`, `spend_route` fan-out resolver, persistence. Unit-tested for determinism + per-party isolation. |
| `onboarding/evtxo.rs` | Creation builds the group + the author's dedicated cosigner + a coordinator policy, instead of one shared `V′` actor. |
| `cosigner/handlers/onboard.rs` | Onboarding reads context from the group record and mints the participant's own dedicated cosigner (no shared roster growth). |
| `rest_api.rs` | `SignStep1`/`SignStep2` fan out `(V′, claimed_share) → cc_id`. |
| `protocol/protos/mpc_wallet.proto` | Doc-only: describe the per-party fan-out. |

## Testing

- `cargo check` (workspace) — clean.
- New unit tests in `contract::group` pass: `cc_id` determinism + per-party uniqueness, and `register_member` isolation (each cosigner's policy holds only its own recipient share, single-entry roster, correct self-route + group fan-out).
- Pre-existing `contract_gate` tests still require the example WASM artifacts to be pre-built (they panic with *"build the contract first"* on a bare checkout — unrelated to this change; CI builds them).

## Notes / scope

Per the agreed scope this is the **structural regrouping only**. The per-write rollback **checksum** mechanism it enables (returning a monotonic checksum to each party so clients can detect host rollback) is a follow-up that builds on these now-isolated per-party write streams. End-to-end enclave verification of the new actor topology is recommended before merge.

https://claude.ai/code/session_011FeY2KHoRDKnXeAGqx8EzB

---
_Generated by [Claude Code](https://claude.ai/code/session_011FeY2KHoRDKnXeAGqx8EzB)_